### PR TITLE
Delay the AST generation time

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,19 +17,30 @@ Designed to be interactive with Scala/Java.
 * 2.3 => Float
 * "s" => String
 * false => Bool
-* () => Nil
 
 ## Composite Types
 
 ### Seq, List
 Sequences and Lists can be constructed by primitive function `seq` and `list`.
 
-* `list`: Construct a `scala.collection.immutable.List`
+* `list`: Construct a `List`
 * `seq`: Construct a `scala.collection.immutable.Vector`
+* `cons` Construct a `List` like all lisp dialects do.
 
 `(seq 1 2 3)` => `#Scala(Vector(1, 2, 3))`
 
 `(.[0] s)` => Access `[0]` element in a sequence.
+Pairs are equivalent to Lists in Lisa.
+`(list 1 2)` = `(cons 1 2)` = `(cons 1 (cons 2 ()))`
+
+If you want to access element by index, use `nth`. 
+If index is out of bounds, throwing `IndexOutOfBoundsException`.
+`(nth s 1)` => Access `1` element in a sequence.
+Or using `get` which will return `()` when index being out of bounds.
+
+`()` equals to empty-list `'()` in most lisp dialects, so does lisa.
+In most cases, `()` will be treated as empty list, but `'()` is not the same reference
+as `()`. So you can still distinguish them via `same-reference?`.
 
 ### Record
 Record is a map-like data structure.
@@ -40,6 +51,9 @@ The `a` attribute of record `s` can be accessed via:
 
 * (.a s) in Java/Scala object style.
 * (s 'a) in Lisa method calling style.
+* (get s "a")
+
+get procedure can be called as `(get map key)` `(get map key not-found)`
 
 ## Syntax
 
@@ -380,7 +394,8 @@ and returns a constant value. E.g. `&1` is equivalent to `(lambda ((... _)) 1)`.
 Defining a macro in Lisa is similar to defining a closure.
 `(define-macro (name args*) body*)` 
 Macros are dynamic scoped. Every argument are passed without any calculation. 
-Macros should eventually return a quoted expression which will be expanded where invoked.
+Macros should eventually return a expression which will be expanded where invoked.
+Since code is data in Lisa, you can generate code by quote and unquote or returning an list.
 To quote an expression, use syntax sugar `'<expression>`. `~<expression>` is the syntax sugar for unquoting an expression.
 
 ```scheme
@@ -403,6 +418,16 @@ To quote an expression, use syntax sugar `'<expression>`. `~<expression>` is the
 
 (is 1 equals to 1) ;=> (= 1 1) => true
 (is 1 not equals to 2) ;=> (if (is 1 equals to 2) false true) => true
+
+(define-macro (unless pred conseq alter)
+    (list 'if pred alter conseq)) ; Can also be '(if ~pred ~alter ~conseq)
+(unless (< 3 2) (println! "3 > 2") (println! "Impossible"))
+
+(define-macro (dirty-nth ls n)
+    (list (string->symbol (string ".[" n "]")) ls))
+(dirty-nth '(1) 0) ; => 1
+(expand-macro '(dirty-nth s 0)); => Apply(.[0], List(s))
+(write (expand-macro '(dirty-nth s 0))) ; => '(.[0] s)
 ```
 
 Notice that though guards are also available in macros, you can not get

--- a/README.md
+++ b/README.md
@@ -393,8 +393,11 @@ and returns a constant value. E.g. `&1` is equivalent to `(lambda ((... _)) 1)`.
 ### Macros
 Defining a macro in Lisa is similar to defining a closure.
 `(define-macro (name args*) body*)` 
-Macros are dynamic scoped. Every argument are passed without any calculation. 
-Macros should eventually return a expression which will be expanded where invoked.
+Macros are executed static scoped. Every argument are passed without any calculation.
+Macros should eventually return an expression which will be expanded where invoked.
+If you want to refer to a value dynamically, use `dynamic-resolve` macro which only works
+inside macros. This macro will lookup through calling chain to resolve the symbol in
+dynamic scope.
 Since code is data in Lisa, you can generate code by quote and unquote or returning an list.
 To quote an expression, use syntax sugar `'<expression>`. `~<expression>` is the syntax sugar for unquoting an expression.
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 name := "lisa"
 
-version := "1.3"
+version := "2.0"
 
 scalaVersion := "2.13.0"
 

--- a/src/main/scala/moe/roselia/lisa/Annotation/RawLisa.scala
+++ b/src/main/scala/moe/roselia/lisa/Annotation/RawLisa.scala
@@ -1,0 +1,8 @@
+package moe.roselia.lisa.Annotation
+
+/**
+ * The annotation to indicate a module or object is a lisa module,
+ * the interpreter will not convert [[moe.roselia.lisa.LispExp.Expression]] to [[Any]]
+ * when calling functions of this module.
+ * */
+class RawLisa extends scala.annotation.StaticAnnotation

--- a/src/main/scala/moe/roselia/lisa/Evaluator.scala
+++ b/src/main/scala/moe/roselia/lisa/Evaluator.scala
@@ -1,9 +1,10 @@
 package moe.roselia.lisa
 
+import java.util.NoSuchElementException
+
 import scala.annotation.tailrec
 import scala.util.Try
-
-import Util.ReflectionHelpers.{ collectException, tryApplyOnObjectReflective, tryToEither }
+import Util.ReflectionHelpers.{collectException, tryApplyOnObjectReflective, tryToEither}
 
 object Evaluator {
   import Environments._
@@ -141,7 +142,7 @@ object Evaluator {
             case SString(document)::_ => simpleMacro.withDocString(document)
             case _ => simpleMacro
           })
-        case _ => Failure("Syntax Error", "Error define a macro")
+        case _ => Failure("Syntax Error", "Error defining a macro")
       }
       case Value("let")::xs => xs match {
         case SList(bounds)::sExpr =>
@@ -205,34 +206,57 @@ object Evaluator {
       case p: PolymorphicExpression => pureValue(p)
       case o@WrappedScalaObject(_) => pureValue(o)
       case r: LisaRecord[_] => pureValue(r)
-      case Define(Symbol(sym), expr) => eval(expr, env) flatMap {
-        case c@Closure(_, _, capturedEnv, _) =>
-//          val notFound = (c.freeVariables - sym).filterNot(capturedEnv.has)
-//          if(notFound.nonEmpty) {
-//            EvalFailure(s"Symbol not found: ${notFound.mkString(", ")}")
-//          } else
-          if(env.directHas(sym)) unit {
-            env.getValueOption(sym).get match {
-              case p: PolymorphicExpression => env.withValue(sym, p.withExpression(c))
-              case closure: Closure =>
-                env.withValue(sym, PolymorphicExpression.create(closure, sym).withExpression(c))
-              case _ => env.withValue(sym, PolymorphicExpression.create(c, sym))
+      case m@SimpleMacro(_, _, _) => pureValue(SimpleMacroClosure.fromMacro(m, env))
+      case m@SimpleMacroClosure(_, _, _, _) => pureValue(m)
+      case Define(Symbol(sym), expr) => eval(expr, env) flatMap { defined =>
+        def updateValue(exp: Expression, isOverride: Boolean = false): Environment = {
+          val predefined = env getValueOption sym
+          val isDeclared = predefined contains PlaceHolder
+          if ((isDeclared || isOverride) && env.isMutable(sym)) {
+            // This variable is previously defined or we need to manually override it.
+            exp match {
+              case or: OriginalEnvironment =>
+                if(isDeclared) or.defineAtEnvironment()
+                else or.defineAtEnvironment(env)
+              case _ =>
             }
-          } else if(c.freeVariables contains sym) {
-            val recursiveFrame = capturedEnv.newMutableFrame
-            val recursiveClosure = c.copy(capturedEnv=recursiveFrame)
-            recursiveFrame.addValue(sym, recursiveClosure)
-            unit(env.withValue(sym, recursiveClosure))
-          } else unit(env.withValue(sym, c))
-        case mac: SimpleMacro if env.directHas(sym) =>
-          unit {
-            env.getValueOption(sym).get match {
-              case p: PolymorphicExpression => env.withValue(sym, p.withExpression(mac))
-              case m: SimpleMacro => env.withValue(sym, PolymorphicExpression.create(m, sym).withExpression(mac))
-              case _ => env.withValue(sym, mac)
+            env.forceUpdated(sym, exp)
+          } else env.withValue(sym, exp)
+        }
+        def isPreviouslyDefined = env.getValueOption(sym).collect {
+          case or: OriginalEnvironment => or.isDefinedAtEnvironment(env)
+        }.contains(true)
+
+        defined match {
+          case c@Closure(_, _, capturedEnv, _) =>
+            //          val notFound = (c.freeVariables - sym).filterNot(capturedEnv.has)
+            //          if(notFound.nonEmpty) {
+            //            EvalFailure(s"Symbol not found: ${notFound.mkString(", ")}")
+            //          } else
+            if(env.directHas(sym) || isPreviouslyDefined) unit {
+              env.getValueOption(sym).get match {
+                case p: PolymorphicExpression => updateValue(p.withExpression(c), isOverride = true)
+                case closure: Closure =>
+                  updateValue(PolymorphicExpression.create(closure, sym).withExpression(c), isOverride = true)
+                case _ => updateValue(PolymorphicExpression.create(c, sym))
+              }
+            } else { // if(c.freeVariables contains sym)
+              val recursiveFrame = capturedEnv.newMutableFrame
+              val recursiveClosure = c.copy(capturedEnv=recursiveFrame)
+              recursiveFrame.addValue(sym, recursiveClosure)
+              unit(updateValue(recursiveClosure))
+            } // else unit(updateValue(c))
+          case mac: SimpleMacroClosure if env.directHas(sym) || isPreviouslyDefined =>
+            unit {
+              env.getValueOption(sym).get match {
+                case p: PolymorphicExpression => updateValue(p.withExpression(mac), isOverride = true)
+                case m: SimpleMacroClosure =>
+                  updateValue(PolymorphicExpression.create(m, sym).withExpression(mac), isOverride = true)
+                case _ => updateValue(mac)
+              }
             }
-          }
-        case result => unit(env.withValue(sym, result))
+          case result => unit(updateValue(result))
+        }
       }
       case LambdaExpression(body, boundVariable, nestedExpressions) =>
         val closure = Closure(boundVariable, body, env, nestedExpressions)
@@ -248,11 +272,7 @@ object Evaluator {
 //      case q: Quote => pureValue(q)
       case Quote(q) => pureValue(q)
       case ll: LisaListLike[_] => pureValue(ll)
-      case UnQuote(q) => eval(q, env) flatMap {
-        case Quote(qt) => pureValue(qt)
-        case _ => EvalFailure(s"Cannot unquote $q.")
-      }
-      case m@SimpleMacro(_, _, _) => pureValue(m)
+      case UnQuote(q) => eval(q, env)
       case pm: PrimitiveMacro => pureValue(pm)
 
       case Apply(func, args) => eval(func, env) flatMap {
@@ -264,8 +284,8 @@ object Evaluator {
                 EvalSuccess(applied._1, applied._2)
               })
           }.fold(EvalFailure.fromThrowable, x => x)
-        case m@SimpleMacro(_, _, _) =>
-          eval(expandMacro(m, args, env), env)
+        case m@SimpleMacroClosure(_, _, _, _) =>
+          eval(expandMacro(m, args.map(_.toRawList), env), env)
         case PrimitiveMacro(m) =>
           Try {
             val (result, newEnv) = m(args, env)
@@ -275,7 +295,7 @@ object Evaluator {
           def executeArgs(args: List[Expression]) =
             pe.findMatch(args, env).map {
               case (ex, _) => ex match {
-                case m: SimpleMacro => eval(expandMacro(m, args, env), env)
+                case m: SimpleMacroClosure => eval(expandMacro(m, args.map(_.toRawList), env), env)
                 case PrimitiveMacro(fn) => fn(args, env) match {
                   case (exp, env) => eval(exp, env)
                 }
@@ -377,10 +397,14 @@ object Evaluator {
                 case Apply(fun, arguments) =>
                   eval(fun, env) flatMap { e =>
                     def tailCallOptimized = 
-                      evalList(arguments, env).map(seq => Apply(e, seq.toList)).map(ReplaceStack(_, env)) match {
-                        case Left(_) => evaluate(body, env)
-                        case Right(value) => value
-                      }
+                      evalList(arguments, env)
+                        // Quote to prevent duplicate execution on eval
+                        .map(_.map(Quote))
+                        .map(seq => Apply(e, seq.toList))
+                        .map(ReplaceStack(_, env)) match {
+                          case Left(_) => evaluate(body, env)
+                          case Right(value) => value
+                        }
                     e match {
                       case _: Closure => tailCallOptimized
                       case poly: PolymorphicExpression if !poly.byName => tailCallOptimized
@@ -413,7 +437,7 @@ object Evaluator {
     }
   }
 
-  def expandMacro(m: SimpleMacro, args: Seq[Expression], env: Environment): Expression = {
+  def expandMacro(m: SimpleMacroClosure, args: Seq[Expression], env: Environment): Expression = {
     def unquote(expression: Expression, env: Environment): Option[Expression] = {
       @`inline` def u(e: Expression) = unquote(e, env)
       def liftOption[T](op: Seq[Option[T]]): Option[Seq[T]] =
@@ -428,7 +452,8 @@ object Evaluator {
 
       expression match {
         case LisaList(ll) => liftOption(ll.map {
-            case sym@UnQuote(Symbol(_)) => u(sym)
+            case UnQuote(LisaList(ull)) => liftOption(ull.map(u)).map(_.toList).map(LisaList(_))
+            case sym@UnQuote(UnQuote(Symbol(_))) => u(sym)
             case ex => u(ex).map(LisaList.from(_))
           }).map(flattenSeq).map(_.toList).map(LisaList(_))
         case Quote(s) => u(s).map(Quote)
@@ -437,8 +462,12 @@ object Evaluator {
         case otherwise => Some(otherwise)
       }
     }
-    val SimpleMacro(paramsPattern, body, defines) = m
-    val evalResult = matchArgument(paramsPattern.toList, args.toList, inEnv = env).map(Env(_, env)).map(newEnv => {
+    val SimpleMacroClosure(paramsPattern, body, defines, capturedEnv) = m
+    val compoundEnvironment = capturedEnv.withValue("dynamic-resolve", PrimitiveMacro {
+      case (Symbol(sym) :: Nil, e) => env.getValueOption(sym).getOrElse(throw new NoSuchElementException(sym)) -> e
+      case _ => throw new IllegalArgumentException(s"dynamic-resolve only accept one symbol.")
+    })
+    val evalResult = matchArgument(paramsPattern.toList, args.toList, inEnv = env).map(Env(_, compoundEnvironment)).map(newEnv => {
       defines.foldLeft[EvalResult](EvalSuccess(NilObj, newEnv)) {
         case (accumulator, define) => accumulator flatMapWithEnv {
           case (_, e) => eval(define, e)

--- a/src/main/scala/moe/roselia/lisa/Evaluator.scala
+++ b/src/main/scala/moe/roselia/lisa/Evaluator.scala
@@ -537,9 +537,10 @@ object Evaluator {
           case _ => None
         }
       case LisaList(Symbol(ctrl@("?" | "when" | "when?")) :: arg::Nil)::Nil => arguments match {
-        case Nil => eval(arg, MutableEnv(matchResult, inEnv)) match {
+        case Nil => eval(unQuoteList(arg), MutableEnv(matchResult, inEnv)) match {
           case EvalSuccess(SBool(b), _) => if (b) Some(matchResult.toMap) else None
-          case EvalSuccess(_, _) => throw new IllegalArgumentException("Matching guard must returns a boolean")
+          case EvalSuccess(exp, _) =>
+            throw new IllegalArgumentException(s"Matching guard must returns a boolean, but $exp: ${exp.tpe.name} found.")
           case EvalFailureMessage(msg) if ctrl != "when?" => throw new ArithmeticException(s"Error in pattern matching: $msg")
           case _ => None // when? means treat exceptions as none.
         }

--- a/src/main/scala/moe/roselia/lisa/Library/IOSource.scala
+++ b/src/main/scala/moe/roselia/lisa/Library/IOSource.scala
@@ -1,5 +1,6 @@
 package moe.roselia.lisa.Library
 import scala.io.Source
+import scala.util.Using
 import java.net.{HttpURLConnection, URI, URL}
 
 import moe.roselia.lisa.Environments.{Environment, SpecialEnv}
@@ -10,13 +11,13 @@ import moe.roselia.lisa.Reflect.ScalaBridge.jsonLikeToLisa
 object IOSource {
   object SourceLibraryImpl {
     def readFileContent(fileName: String): String = {
-      Source.fromFile(fileName).mkString
+      Using.resource(Source.fromFile(fileName))(_.mkString)
     }
     def readFromUri(uri: String): String = {
-      Source.fromURI(new URI(uri)).mkString
+      Using.resource(Source.fromURI(new URI(uri)))(_.mkString)
     }
     def readFromUrl(url: String): String = {
-      Source.fromURL(new URL(url)).mkString
+      Using.resource(Source.fromURL(new URL(url)))(_.mkString)
     }
 
     def parseJsonOption(json: String): Option[Expression] = {

--- a/src/main/scala/moe/roselia/lisa/LispExp.scala
+++ b/src/main/scala/moe/roselia/lisa/LispExp.scala
@@ -640,9 +640,9 @@ object LispExp {
 
     def withExpression(closure: Closure): PolymorphicExpression = closure match {
       case c@Closure(_, _, capturedEnv, _) =>
-        val nc =
-          if (c.freeVariables.contains(name)) c.copy(capturedEnv = CombineEnv.of(innerEnvironment, capturedEnv))
-          else c
+        val nc = c.copy(capturedEnv = CombineEnv.of(innerEnvironment, capturedEnv))
+//          if (c.freeVariables.contains(name)) c.copy(capturedEnv = CombineEnv.of(innerEnvironment, capturedEnv))
+//          else c
         val newPolymorphic = copy(variants = variants.appended((nc, nc.boundVariable)))
         nc.withSelf(newPolymorphic)
         innerEnvironment.addValue(name, newPolymorphic)

--- a/src/main/scala/moe/roselia/lisa/LispExp.scala
+++ b/src/main/scala/moe/roselia/lisa/LispExp.scala
@@ -1,9 +1,10 @@
 package moe.roselia.lisa
 
-import Environments.{CombineEnv, EmptyEnv, Environment, MutableEnv}
-import RecordType.{MapRecord, Record}
+import moe.roselia.lisa.Environments.{CombineEnv, EmptyEnv, Environment, MutableEnv}
+import moe.roselia.lisa.RecordType.{MapRecord, Record}
 
 import scala.annotation.tailrec
+import scala.collection.mutable
 
 object LispExp {
 
@@ -15,6 +16,7 @@ object LispExp {
 
   trait DocumentAble {
     var document = ""
+
     def withDocString(string: String): this.type = {
       document = string
       this
@@ -35,13 +37,17 @@ object LispExp {
 
   trait WithFreeValues {
     def freeVariables: Set[String] = collectEnvDependency(Set.empty)._1
+
     def freeVariables(env: Environment) = collectEnvDependency(Set.empty, env, Nil)._1
+
     def collectEnvDependency(defined: Set[String]): (Set[String], Set[String]) = {
       // (Dependency, NewDefined)
       collectEnvDependency(defined, EmptyEnv, Nil)
     }
+
     def collectEnvDependency(defined: Set[String], env: Environment, context: List[Expression] = Nil): (Set[String], Set[String]) =
       collectEnvDependency(defined)
+
     protected def accumulateDependencies(expressions: List[Expression], initial: Set[String]) =
       expressions.foldLeft(Set.empty[String] -> initial) {
         case ((dependency, defined), expression) =>
@@ -71,9 +77,15 @@ object LispExp {
     def value: String
 
     override def toString: String = value
+
     override def collectEnvDependency(defined: Set[String]): (Set[String], Set[String]) = {
       val dep = if (defined contains value) Set.empty[String] else Set(value)
       dep -> defined
+    }
+
+    override def equals(obj: Any): Boolean = obj match {
+      case Symbol(sym) => sym == value
+      case x => super.equals(x)
     }
   }
 
@@ -84,11 +96,13 @@ object LispExp {
   }
 
   case class PlainSymbol(value: String) extends Symbol
+
   case class GraveAccentSymbol(value: String) extends Symbol
+
+  import Rational.Implicits._
 
   import Numeric.Implicits._
   import Ordering.Implicits._
-  import Rational.Implicits._
 
   type LisaInteger = BigInt
   val LisaInteger = BigInt
@@ -96,23 +110,27 @@ object LispExp {
   type LisaDecimal = BigDecimal
   val LisaDecimal = BigDecimal
 
-  import LisaInteger.int2bigInt
   import LisaDecimal.double2bigDecimal
+  import LisaInteger.int2bigInt
 
   class SNumber[T](val number: T)(implicit evidence: scala.math.Numeric[T])
     extends Expression with Ordered[SNumber[T]] with NoExternalDependency with LisaValue {
     override def toString: String = number.toString
-    def mapTo[U : Numeric](implicit transform: T => U): SNumber[U] = SNumber(number)
+
+    def mapTo[U: Numeric](implicit transform: T => U): SNumber[U] = SNumber(number)
+
     def toIntNumber: SNumber[LisaInteger] = number match {
       case _: LisaInteger => this.asInstanceOf[SNumber[LisaInteger]]
       case _ => SInteger(toRationalNumber.number.toIntegral)
     }
+
     def toDoubleNumber: SNumber[LisaDecimal] = number match {
       case _: LisaDecimal => this.asInstanceOf[SNumber[LisaDecimal]]
       case num: Rational[LisaInteger] => LisaDecimal(num.numerator) / LisaDecimal(num.denominator)
       case n: LisaInteger => LisaDecimal(n)
       case _ => SFloat(number.toDouble)
     }
+
     def toRationalNumber: SNumber[Rational[LisaInteger]] = {
       import SNumber.NumberTypes._
       getTypeOrder(number) match {
@@ -121,9 +139,13 @@ object LispExp {
         case _ => Rational.fromDouble[LisaInteger](number.toDouble)
       }
     }
+
     def +(that: SNumber[T]): SNumber[T] = number + that.number
+
     def -(that: SNumber[T]): SNumber[T] = number - that.number
+
     def *(that: SNumber[T]): SNumber[T] = number * that.number
+
     def /(that: SNumber[T]): SNumber[Any] = {
       import SNumber.NumberTypes._
       val flag = commonLargestType(this, that)
@@ -140,14 +162,19 @@ object LispExp {
         SNumber(thisDecimal / thatDecimal).asInstanceOf[SNumber[Any]]
       }
     }
+
     def unary_- : SNumber[T] = -number
+
     override def compare(that: SNumber[T]): Int = implicitly[Ordering[T]].compare(number, that.number)
+
     def max(that: SNumber[T]): SNumber[T] = number max that.number
+
     def min(that: SNumber[T]): SNumber[T] = number min that.number
+
     def equalsTo(that: SNumber[T]): Boolean = number equiv that.number
 
     override def equals(obj: Any): Boolean = obj match {
-//      case num: SNumber[T] => equalsTo(num)
+      //      case num: SNumber[T] => equalsTo(num)
       case that: SNumber[_] => SNumber.performComputation(_ equalsTo _)(this, that)
       case other => super.equals(other)
     }
@@ -163,32 +190,38 @@ object LispExp {
   }
 
   object SNumber {
-    implicit def wrapToSNumber[T : Numeric](t: T): SNumber[T] = apply(t)
-    def apply[T : Numeric](number: T): SNumber[T] = number match {
+    implicit def wrapToSNumber[T: Numeric](t: T): SNumber[T] = apply(t)
+
+    def apply[T: Numeric](number: T): SNumber[T] = number match {
       case s: LisaInteger => SInteger(s).asInstanceOf[SNumber[T]]
       case s: LisaDecimal => SFloat(s).asInstanceOf[SNumber[T]]
       case s: Rational[LisaInteger] => SRational(s).asInstanceOf[SNumber[T]]
       case s => new SNumber(s)
     }
 
-    implicit def convertNumberTypes[T, U : Numeric](number: SNumber[T])(implicit transform: T => U): SNumber[U] =
+    implicit def convertNumberTypes[T, U: Numeric](number: SNumber[T])(implicit transform: T => U): SNumber[U] =
       number.mapTo[U]
+
     def performComputation[T](f: (SNumber[Any], SNumber[Any]) => T)(a: SNumber[_], b: SNumber[_]): T = {
       val (x, y) = NumberTypes.handleCommonLargestType(a, b)
       f(x, y)
     }
+
     object NumberTypes {
+
       object TypeFlags {
         val Integer = 1
         val Rational = 2
         val Double = 3
       }
+
       def getTypeOrder(obj: Any) = obj match {
         case _: Int | _: Integer | _: LisaInteger => TypeFlags.Integer
         case _: Rational[_] => TypeFlags.Rational
         case _: Float | _: Double | _: java.lang.Double | _: java.lang.Float | _: LisaDecimal =>
           TypeFlags.Double
       }
+
       def castToType(flag: Int)(obj: SNumber[_]): SNumber[_] = {
         flag match {
           case TypeFlags.Integer => obj.toIntNumber
@@ -205,12 +238,14 @@ object LispExp {
         castToType(flag)(a).asInstanceOf[SNumber[Any]] -> castToType(flag)(b).asInstanceOf[SNumber[Any]]
       }
     }
+
   }
 
   case class SInteger(value: LisaInteger) extends SNumber(value)
 
   object SInteger {
     private val integerCache = (-127 to 128).map(LisaInteger(_)).map(new SInteger(_))
+
     def apply(value: LisaInteger): SInteger = value match {
       case v if v >= -127 && v <= 128 => integerCache(v.toInt + 127)
       case v => new SInteger(v)
@@ -226,14 +261,20 @@ object LispExp {
 
     override def tpe: LisaType = NameOnlyType("Boolean")
   }
+
   object SBool {
     def apply(value: Boolean): SBool =
       if (value) SBool.True else SBool.False
+
     val True: SBool = new SBool(true)
     val False: SBool = new SBool(false)
   }
 
-  case class SString(value: String) extends Expression with NoExternalDependency with Ordered[SString] with LisaValue {
+  case class SString(value: String)
+    extends Expression
+      with NoExternalDependency
+      with Ordered[SString]
+      with LisaValue {
     override def toString: String = value.toString
 
     override def code: String = {
@@ -244,8 +285,12 @@ object LispExp {
     override def compare(that: SString): Int = value compare that.value
   }
 
-  case object NilObj extends Expression with NoExternalDependency with LisaValue {
+  case object NilObj extends Expression with NoExternalDependency with LisaValue with LisaListLike[Nothing] {
+    override def list: List[Nothing] = Nil
+
     override def toString: String = "( )"
+
+    override def tpe: LisaType = NameOnlyType("Nil")
   }
 
   case class WrappedScalaObject[+T](obj: T) extends Expression with NoExternalDependency with LisaValue {
@@ -255,6 +300,8 @@ object LispExp {
 
     override def tpe: LisaType =
       NameOnlyType(s"${getClass.getSimpleName}[${reflect.NameTransformer.decode(obj.getClass.getSimpleName)}]")
+
+    override def equals(obj: Any): Boolean = super.equals(obj) || this.obj == obj
   }
 
   object WrappedScalaObject {
@@ -272,6 +319,16 @@ object LispExp {
     extends Procedure with DeclareArityAfter with NoExternalDependency {
     override def toString: String = s"#[Native Code]($function)"
   }
+
+  object PrimitiveFunction {
+    def withArityChecked(arity: Int)(function: PartialFunction[List[Expression], Expression]): PrimitiveFunction = {
+      PrimitiveFunction({
+        case xs if xs.length == arity => function(xs)
+        case xs => throw new IllegalArgumentException(s"Arity Mismatch: Expected: $arity Given: ${xs.length}")
+      }).withArity(arity)
+    }
+  }
+
   case class SideEffectFunction(function: (List[Expression], Environment) => (Expression, Environment))
     extends Procedure with NoExternalDependency {
     override def toString: String = "#[Native Code!]"
@@ -289,7 +346,7 @@ object LispExp {
                                       context: List[Expression]): (Set[String], Set[String]) = {
       val innerDefinition = getBoundVariables(boundVariable) ++ defined
       val guardDependency = boundVariable.lastOption.map {
-        case Apply(Symbol("?" | "when" | "when?"), xs::Nil) =>
+        case LisaList(Symbol("?" | "when" | "when?") :: xs :: Nil) =>
           xs.collectEnvDependency(innerDefinition)._1
         case _ => Set.empty[String]
       }.getOrElse(Set.empty)
@@ -303,8 +360,10 @@ object LispExp {
     }
   }
 
-  trait SelfReferencable { this: Expression =>
+  trait SelfReferencable {
+    this: Expression =>
     var selfReference: Expression = this
+
     def withSelf(self: Expression): this.type = {
       selfReference = self
       this
@@ -320,7 +379,7 @@ object LispExp {
 
     override def toString: String = s"#Closure[${genHead(boundVariable)}]"
 
-    override def docString: String = s"${genHead(boundVariable)}: ${if(document.isEmpty) code else document}"
+    override def docString: String = s"${genHead(boundVariable)}: ${if (document.isEmpty) code else document}"
 
     def copy(boundVariable: List[Expression] = boundVariable,
              body: Expression = body,
@@ -334,7 +393,7 @@ object LispExp {
 
     override lazy val arity: Option[Int] = getArityOfPattern(boundVariable)
 
-    override def pattern: List[List[Expression]] = boundVariable::Nil
+    override def pattern: List[List[Expression]] = boundVariable :: Nil
 
     override def isDefinedAt(input: List[Expression], _env: Environment): Boolean =
       super.isDefinedAt(input, capturedEnv)
@@ -342,30 +401,31 @@ object LispExp {
     override def collectEnvDependency(defined: Set[String]): (Set[String], Set[String]) =
       rawLambdaExpression collectEnvDependency defined
 
-    def flattenCaptured: Closure = copy(capturedEnv=capturedEnv.collectValues(freeVariables.toList))
+    def flattenCaptured: Closure = copy(capturedEnv = capturedEnv.collectValues(freeVariables.toList))
   }
 
-  case class SIfElse(predicate: Expression, consequence: Expression, alternative: Expression) extends Procedure {
+  case class SIfElse(predicate: Expression, consequence: Expression, alternative: Expression) extends Expression {
     override def valid: Boolean = predicate.valid && consequence.valid && alternative.valid
 
     override def code: String = s"(if ${predicate.code} ${consequence.code} ${alternative.code})"
 
     override def collectEnvDependency(defined: Set[String]): (Set[String], Set[String]) =
-      accumulateDependencies(predicate::consequence::alternative::Nil, defined)
+      accumulateDependencies(predicate :: consequence :: alternative :: Nil, defined)
   }
+
   case class SCond(conditions: List[(Expression, Expression)]) extends Expression {
     override def collectEnvDependency(defined: Set[String]): (Set[String], Set[String]) =
-      accumulateDependencies(conditions.flatMap(it => it._1::it._2::Nil), defined)
+      accumulateDependencies(conditions.flatMap(it => it._1 :: it._2 :: Nil), defined)
   }
 
   case class Apply(head: Expression, args: List[Expression]) extends Expression {
     override def valid: Boolean = head.valid && args.forall(_.valid)
 
     override def code: String =
-      if(args.isEmpty) s"(${head.code})" else s"(${head.code} ${args.map(_.code).mkString(" ")})"
+      if (args.isEmpty) s"(${head.code})" else s"(${head.code} ${args.map(_.code).mkString(" ")})"
 
     override def collectEnvDependency(defined: Set[String]): (Set[String], Set[String]) = {
-      accumulateDependencies(head::args, defined)
+      accumulateDependencies(head :: args, defined)
     }
 
     override def collectEnvDependency(defined: Set[String],
@@ -415,30 +475,30 @@ object LispExp {
   def genHead(ex: Seq[Expression]): String = {
     if (ex.isEmpty) "()"
     else ex.last match {
-      case Apply(Symbol("?" | "when"), xs::Nil) => s"${genHead(ex.init)} when ${xs.code}"
-      case Apply(Symbol("when?"), xs::Nil) => s"${genHead(ex.init)} when? ${xs.code}"
-      case Apply(Symbol("..."), Symbol(x)::Nil) => genHead(ex.init appended Symbol(s"...$x"))
+      case LisaList(Symbol("?" | "when") :: xs :: Nil) => s"${genHead(ex.init)} when ${xs.code}"
+      case LisaList(Symbol("when?") :: xs :: Nil) => s"${genHead(ex.init)} when? ${xs.code}"
+      case LisaList(Symbol("...") :: Symbol(x) :: Nil) => genHead(ex.init appended Symbol(s"...$x"))
       case _ => s"(${ex.map(_.code).mkString(" ")})"
     }
   }
 
   def getBoundVariables(pat: List[Expression]): Set[String] = pat match {
     case Nil => Set.empty
-    case Apply(Symbol("..."), Symbol(sym)::Nil)::Nil => Set(sym)
-    case Apply(Symbol("?" | "when?" | "when"), _)::Nil => Set.empty
-    case Symbol("_")::xs => getBoundVariables(xs)
-    case Symbol(sym)::xs => getBoundVariables(xs) + sym
-    case Apply(Symbol("seq"), args)::xs => getBoundVariables(xs) ++ getBoundVariables(args)
-    case Apply(ex, args)::xs => getBoundVariables(ex::xs) ++ getBoundVariables(args)
-    case _::xs => getBoundVariables(xs)
+    case LisaList(Symbol("...") :: Symbol(sym) :: Nil) :: Nil => Set(sym)
+    case LisaList(Symbol("?" | "when?" | "when") :: _) :: Nil => Set.empty
+    case Symbol("_") :: xs => getBoundVariables(xs)
+    case Symbol(sym) :: xs => getBoundVariables(xs) + sym
+    case LisaList(Symbol("seq") :: args) :: xs => getBoundVariables(xs) ++ getBoundVariables(args)
+    case LisaList(ex :: args) :: xs => getBoundVariables(ex :: xs) ++ getBoundVariables(args)
+    case _ :: xs => getBoundVariables(xs)
   }
 
   @tailrec
-  def getArityOfPattern(pat: List[Expression], accumulator: Int = 0): Option[Int] = pat match {
+  def getArityOfPattern(pat: Seq[Expression], accumulator: Int = 0): Option[Int] = pat.toList match {
     case Nil => Some(accumulator)
-    case Apply(Symbol("..."), _)::Nil => None // Can not count arity on va-args.
-    case Apply(Symbol("?" | "when?" | "when"), _)::Nil => Some(accumulator) // Match guards
-    case _::xs => getArityOfPattern(xs, accumulator + 1)
+    case LisaList(Symbol("...") :: _) :: Nil => None // Can not count arity on va-args.
+    case LisaList(Symbol("?" | "when?" | "when") :: _) :: Nil => Some(accumulator) // Match guards
+    case _ :: xs => getArityOfPattern(xs, accumulator + 1)
   }
 
   trait MayHaveArity {
@@ -446,7 +506,7 @@ object LispExp {
   }
 
   trait DeclareArityAfter extends MayHaveArity {
-    private [this] var _arity: Option[Int] = None
+    private[this] var _arity: Option[Int] = None
 
     override def arity: Option[Int] = _arity
 
@@ -459,20 +519,20 @@ object LispExp {
   case class SimpleMacro(paramsPattern: Seq[Expression],
                          body: Expression,
                          defines: Seq[Expression])
-    extends Expression with MayHaveArity with MayBeDefined with NoExternalDependency {
+    extends Procedure with MayHaveArity with MayBeDefined with NoExternalDependency {
     override def valid: Boolean = paramsPattern.forall(_.valid) && body.valid && defines.forall(_.valid)
 
     override def toString: String = s"#Macro(${paramsPattern.mkString(" ")})"
 
     override def code: String = LambdaExpression(body, paramsPattern.toList, defines.toList).code
 
-    override lazy val arity: Option[Int] = getArityOfPattern(paramsPattern.toList)
+    override lazy val arity: Option[Int] = getArityOfPattern(paramsPattern)
 
-    override def pattern: List[List[Expression]] = paramsPattern.toList::Nil
+    override def pattern: List[List[Expression]] = paramsPattern.toList :: Nil
   }
 
   case class PrimitiveMacro(fn: (List[Expression], Environment) => (Expression, Environment))
-    extends Expression with DeclareArityAfter with NoExternalDependency {
+    extends Procedure with DeclareArityAfter with NoExternalDependency {
     override def toString: String = s"#Macro![Native Code]"
   }
 
@@ -482,14 +542,14 @@ object LispExp {
 
   case class PolymorphicExpression(name: String,
                                    variants: Seq[(Expression, Seq[Expression])],
-                                   innerEnvironment: MutableEnv, byName: Boolean=false)
-    extends Expression with MayHaveArity with MayBeDefined {
+                                   innerEnvironment: MutableEnv, byName: Boolean = false)
+    extends Procedure with MayHaveArity with MayBeDefined {
     def findMatch(args: Seq[Expression],
                   inEnv: Environment = EmptyEnv): Option[(Expression, Map[String, Expression])] = {
       @annotation.tailrec
       def find(v: List[(Expression, Seq[Expression])]): Option[(Expression, Map[String, Expression])] = v match {
         case Nil => None
-        case (exp, mat)::xs =>
+        case (exp, mat) :: xs =>
           val env = exp match {
             case Closure(_, _, capturedEnv, _) => capturedEnv
             case _ => inEnv
@@ -499,17 +559,18 @@ object LispExp {
             case _ => find(xs)
           }
       }
+
       val found = find(variants.toList)
-//      if(found.isDefined) println(s"${found.get} matches $args")
+      //      if(found.isDefined) println(s"${found.get} matches $args")
       found
     }
 
     def withExpression(closure: Closure): PolymorphicExpression = closure match {
       case c@Closure(_, _, capturedEnv, _) =>
         val nc =
-          if(c.freeVariables.contains(name)) c.copy(capturedEnv=CombineEnv.of(innerEnvironment, capturedEnv))
+          if (c.freeVariables.contains(name)) c.copy(capturedEnv = CombineEnv.of(innerEnvironment, capturedEnv))
           else c
-        val newPolymorphic = copy(variants=variants.appended((nc, nc.boundVariable)))
+        val newPolymorphic = copy(variants = variants.appended((nc, nc.boundVariable)))
         nc.withSelf(newPolymorphic)
         innerEnvironment.addValue(name, newPolymorphic)
         newPolymorphic
@@ -517,17 +578,17 @@ object LispExp {
 
 
     def withExpression(mac: SimpleMacro): PolymorphicExpression = {
-      val newVariant = copy(variants=variants.appended((mac, mac.paramsPattern)))
+      val newVariant = copy(variants = variants.appended((mac, mac.paramsPattern)))
       innerEnvironment.addValue(name, newVariant)
       newVariant
     }
 
     override def docString: String = {
-      if(variants.length == 1) {
+      if (variants.length == 1) {
         variants.head._1.docString
       } else {
         val body = variants.map {
-          case (p, v) => if(p.docString.nonEmpty) p.docString else s"${genHead(v)}: ${p.code}"
+          case (p, v) => if (p.docString.nonEmpty) p.docString else s"${genHead(v)}: ${p.code}"
         }.mkString("\n")
         s"""
            |$name is a polymorphic function, with ${variants.length} overloads:
@@ -552,9 +613,9 @@ object LispExp {
         .flatMap {
           case (exp, _) => Evaluator.applyToEither(exp, arguments).map(_.toString).toOption
         }.getOrElse(verboseString)
-//      if (isDefinedAt(Symbol("to-string")::Nil, EmptyEnv))
-//        Evaluator.apply(this, Symbol("to-string") :: Nil).toOption.map(_.toString).getOrElse(verboseString)
-//      else verboseString
+      //      if (isDefinedAt(Symbol("to-string")::Nil, EmptyEnv))
+      //        Evaluator.apply(this, Symbol("to-string") :: Nil).toOption.map(_.toString).getOrElse(verboseString)
+      //      else verboseString
     }
 
     override lazy val arity: Option[Int] =
@@ -610,27 +671,30 @@ object LispExp {
       @scala.annotation.tailrec
       def recurHelper(rec: List[Expression], acc: Map[String, Expression]): Map[String, Expression] = rec match {
         case Nil => acc
-        case Symbol(sym)::exp::xs => recurHelper(xs, acc.updated(sym, exp))
-        case Quote(Symbol(sym))::exp::xs => recurHelper(xs, acc.updated(sym, exp))
-        case (r: LisaRecordWithMap[_])::xs => recurHelper(xs, acc ++ r.record)
-        case x:: _ ::_ => throw new IllegalArgumentException(s"Unrecognized key type: $x: ${x.tpe.name}")
-        case x::_ => throw new IllegalArgumentException(s"No matching value for $x")
+        case Symbol(sym) :: exp :: xs => recurHelper(xs, acc.updated(sym, exp))
+        case Quote(Symbol(sym)) :: exp :: xs => recurHelper(xs, acc.updated(sym, exp))
+        case (r: LisaRecordWithMap[_]) :: xs => recurHelper(xs, acc ++ r.record)
+        case x :: _ :: _ => throw new IllegalArgumentException(s"Unrecognized key type: $x: ${x.tpe.name}")
+        case x :: _ => throw new IllegalArgumentException(s"No matching value for $x")
       }
+
       LisaMapRecord(recurHelper(rec, Map.empty), name)
     }
 
     def recordUpdater(rec: LisaRecordWithMap[Expression], arguments: List[Expression]) = {
       type V = Expression
+
       @annotation.tailrec
       def update(args: List[Expression], acc: LisaRecordWithMap[V]): LisaRecordWithMap[V] = args match {
         case Nil => acc
-        case Symbol(sym)::exp::xs => update(xs, acc.updated(sym, exp))
-        case Quote(Symbol(sym))::exp::xs => update(xs, acc.updated(sym, exp))
-        case (r: LisaRecordWithMap[_])::xs =>
+        case Symbol(sym) :: exp :: xs => update(xs, acc.updated(sym, exp))
+        case Quote(Symbol(sym)) :: exp :: xs => update(xs, acc.updated(sym, exp))
+        case (r: LisaRecordWithMap[_]) :: xs =>
           update(xs, r.record.foldLeft(acc) { case (acc, (k, v)) => acc.updated(k, v) })
-        case x:: _ ::_ => throw new IllegalArgumentException(s"Unrecognized key type: $x: ${x.tpe.name}")
-        case x::_ => throw new IllegalArgumentException(s"No matching value for $x")
+        case x :: _ :: _ => throw new IllegalArgumentException(s"Unrecognized key type: $x: ${x.tpe.name}")
+        case x :: _ => throw new IllegalArgumentException(s"No matching value for $x")
       }
+
       update(arguments, rec)
     }
 
@@ -649,7 +713,7 @@ object LispExp {
 
     lazy val RecordHelperEnv = Environments.Env(Map(
       "record" -> PrimitiveFunction {
-        case SString(name)::xs =>
+        case SString(name) :: xs =>
           recordMaker(xs, name)
         case xs =>
           recordMaker(xs)
@@ -708,6 +772,7 @@ object LispExp {
       }
     ), EmptyEnv)
   }
+
   trait LisaRecordWithMap[+V <: Expression] extends LisaRecord[V] with MapRecord[String, V] {
     override def toString: String = {
       val body = record.map {
@@ -715,6 +780,7 @@ object LispExp {
       }.mkString(" ")
       s"$recordTypeName {$body}".stripLeading
     }
+
     def updated[B >: V <: Expression](key: String, value: B): LisaRecordWithMap[B]
   }
 
@@ -726,6 +792,7 @@ object LispExp {
   case class TypedLisaRecord[+V <: Expression](record: Map[String, V], recordType: LisaType)
     extends LisaRecordWithMap[V] {
     override def recordTypeName: String = recordType.name
+
     override def updated[B >: V <: Expression](key: String, value: B): TypedLisaRecord[B] =
       if (record.contains(key)) copy(record.updated(key, value))
       else throw new IllegalArgumentException(s"Attribute $key does not exist on type $recordTypeName")
@@ -733,12 +800,51 @@ object LispExp {
     override def tpe: LisaType = recordType
   }
 
+  trait LisaListLike[+T]
+    extends Seq[T]
+      with Expression {
+    def list: List[T]
+
+    override def apply(i: Int): T = list(i)
+
+    override def length: Int = list.length
+
+    override def iterator: Iterator[T] = list.iterator
+
+    def wrapped: WrappedScalaObject[List[T]] = WrappedScalaObject(list)
+
+    override def equals(o: Any): Boolean = o match {
+      case l: Seq[_] => l == list
+      case WrappedScalaObject(l) => l == list
+      case _ => super.equals(o)
+    }
+  }
+
+  case class LisaList[+T <: Expression](list: List[T])
+    extends LisaListLike[T] {
+    override def tpe: LisaType = NameOnlyType("List")
+
+    override def toString: String = list.mkString("(", " ", ")")
+
+    override def code: String = s"${list.map(_.code).mkString("(", " ", ")")}"
+  }
+
+  object LisaList {
+    private val nil: LisaList[Nothing] = LisaList(Nil)
+
+    def apply[T <: Expression](list: List[T]) = new LisaList(list)
+    def from[T <: Expression](list: T*) = new LisaList(list.toList)
+    def empty[T <: Expression]: LisaList[T] = nil
+    def newBuilder[A <: Expression]: mutable.Builder[A, LisaList[A]] = List.newBuilder.mapResult(apply)
+  }
+
   trait Implicits {
     import scala.language.implicitConversions
+
     implicit def fromInt(i: Int): SInteger = SInteger(i)
     implicit def fromBigInt(i: LisaInteger): SInteger = SInteger(i)
     implicit def fromString(s: String): SString = SString(s)
-    implicit def fromSymbol(sym: scala.Symbol):Symbol = Symbol(sym.name)
+    implicit def fromSymbol(sym: scala.Symbol): Symbol = Symbol(sym.name)
     implicit def fromFloat(f: Float): SFloat = SFloat(LisaDecimal(f))
     implicit def fromDouble(f: Double): SFloat = SFloat(LisaDecimal(f))
     implicit def fromDecimal(f: LisaDecimal): SFloat = SFloat(f)

--- a/src/main/scala/moe/roselia/lisa/Main.scala
+++ b/src/main/scala/moe/roselia/lisa/Main.scala
@@ -63,7 +63,7 @@ object Main {
                   result match {
                     case LispExp.Failure(typ, msg) =>
                       printlnErr(s"$typ: $msg")
-                    case NilObj =>
+                    case s if s eq NilObj =>
                     case s =>
                       println(s"[$resultIndex]: ${s.tpe.name} = $s")
                   }

--- a/src/main/scala/moe/roselia/lisa/Reflect/DotAccessor.scala
+++ b/src/main/scala/moe/roselia/lisa/Reflect/DotAccessor.scala
@@ -4,6 +4,7 @@ import scala.reflect.ClassTag
 import moe.roselia.lisa.Environments.SpecialEnv
 import moe.roselia.lisa.LispExp
 import ScalaBridge._
+import moe.roselia.lisa.LispExp.{LisaList, WrappedScalaObject}
 import moe.roselia.lisa.Util.Extractors.NeedInt
 
 object DotAccessor {
@@ -148,8 +149,11 @@ object DotAccessor {
     override def getValueOption(key: String): Option[LispExp.Expression] = Some(LispExp.PrimitiveFunction {
       case x::Nil =>
         key.substring(1) match {
-          case s"[${NeedInt(index)}]" =>
-            fromScalaNative(toScalaNative(x).asInstanceOf[Seq[Any]](index))
+          case s"[${NeedInt(index)}]" => x match {
+            case LisaList(ll) => ll(index)
+            case WrappedScalaObject(seq: Seq[_]) => fromScalaNative(seq(index))
+            case _ => fromScalaNative(toScalaNative(x).asInstanceOf[Seq[Any]](index))
+          }
           case field =>
             val res = accessDot(field)(toScalaNative(x))
             fromScalaNative(res)

--- a/src/main/scala/moe/roselia/lisa/Reflect/DotAccessor.scala
+++ b/src/main/scala/moe/roselia/lisa/Reflect/DotAccessor.scala
@@ -4,6 +4,7 @@ import scala.reflect.ClassTag
 import moe.roselia.lisa.Environments.SpecialEnv
 import moe.roselia.lisa.LispExp
 import ScalaBridge._
+import moe.roselia.lisa.Annotation.RawLisa
 import moe.roselia.lisa.LispExp.{LisaList, WrappedScalaObject}
 import moe.roselia.lisa.Util.Extractors.NeedInt
 
@@ -16,6 +17,10 @@ object DotAccessor {
     val cls = obj.getClass
     val mirror = runtimeMirror(cls.getClassLoader)
     mirror.reflect(obj)
+  }
+
+  def hasRawLisaAnnotation(symbol: Symbol): Boolean = {
+    symbol.annotations.view.map(_.tree.tpe).exists(_ <:< typeOf[RawLisa])
   }
 
   def accessDotDynamic(acc: String)(dyn: Dynamic): Any = {
@@ -86,10 +91,11 @@ object DotAccessor {
   }
 
   def lookUpForTerm(symbol: ClassSymbol, accessName: String) = {
+    val termName = TermName(toJvmName(accessName))
     (symbol :: symbol.baseClasses).view
       .map(_.asClass)
       .map(_.toType)
-      .map(_.decl(TermName(toJvmName(accessName))))
+      .map(_.decl(termName))
       .find(_.isTerm)
       .map(_.asTerm)
   }

--- a/src/main/scala/moe/roselia/lisa/Util/CollectionHelper.scala
+++ b/src/main/scala/moe/roselia/lisa/Util/CollectionHelper.scala
@@ -1,0 +1,56 @@
+package moe.roselia.lisa.Util
+
+import moe.roselia.lisa.Evaluator
+import moe.roselia.lisa.LispExp.{Closure, Expression, Failure, LisaListLike, PrimitiveFunction, SBool, SString, WrappedScalaObject}
+import moe.roselia.lisa.Reflect.ScalaBridge.fromScalaNative
+
+object CollectionHelper {
+  /**
+   * Helper to deal with boxed collections and native collections
+   */
+
+
+  def generalMap(ls: Iterable[Any], fn: Expression): Iterable[Expression] = fn match {
+    case c: Closure =>
+      val newList = ls.map(x => Evaluator.applyToEither(c, List(fromScalaNative(x))))
+      if(newList forall (_.isRight))
+        newList.map(_.toOption.get)
+      else newList.find(_.isLeft).get.left.toOption.map(err => throw new RuntimeException(s"map Error: $err"))
+    case PrimitiveFunction(fn) =>
+      ls.map(x => fn(List(fromScalaNative(x))))
+    case _ => throw new RuntimeException(s"map Error: Cannot map $fn on $ls")
+  }
+
+  def generalFilter(ls: Iterable[Expression], fn: Expression): Iterable[Expression] = {
+    def ensureBool(e: Expression) = e match {
+      case SBool(b) => b
+      case _ => throw new IllegalArgumentException("Function should return a Bool.")
+    }
+    def reportFilterError(reason: String) = throw new RuntimeException(s"filter Error: $reason")
+
+    fn match {
+      case c: Closure =>
+        val newList = ls.map(x => Evaluator.applyToEither(c, List(fromScalaNative(x))))
+        if(newList forall (_.isRight))
+          newList.map(_.toOption.get).zip(ls).filter(x => ensureBool(x._1)).map(_._2)
+        else newList.find(_.isLeft).get.left.toOption.map(reportFilterError)
+      case PrimitiveFunction(fn) =>
+        ls.filter(x => ensureBool(fn(List(fromScalaNative(x)))))
+      case WrappedScalaObject(obj) =>
+        ls.filter(x =>
+          obj.asInstanceOf[{def apply(a: Any): Boolean}].apply(x))
+      case _ => reportFilterError(s"Cannot filter $fn on $ls")
+    }
+  }
+
+  def lazyConst[T, U](x: => T)(y: U): T = x
+
+  def generalGetElementOfSeqLike(coll: Expression, index: Int, default: => Expression): Expression = coll match {
+    case ll: LisaListLike[Expression] => ll.applyOrElse(index, lazyConst(default))
+    case WrappedScalaObject(it: Iterable[_]) =>
+      fromScalaNative(it.toSeq.applyOrElse(index, lazyConst(default)))
+    case SString(value) => SString(value.applyOrElse(index, lazyConst(default)).toString)
+    case xs: Iterable[_] => fromScalaNative(xs.view.toSeq.applyOrElse(index, lazyConst(default)))
+    case xs => throw new IllegalArgumentException(s"Contract violation: ${xs.tpe.name} is not seq-like.")
+  }
+}

--- a/src/main/scala/moe/roselia/lisa/Util/ReturnControlFlow.scala
+++ b/src/main/scala/moe/roselia/lisa/Util/ReturnControlFlow.scala
@@ -14,8 +14,8 @@ object ReturnControlFlow {
     def returns[U >: T](value: U) = throw ReturnException(value, returnFlag)
 
     def returnable[U >: T](op: => U): U = try op catch {
-      case ReturnException(result, `returnFlag`) =>
-        result.asInstanceOf[U]
+      case ReturnException(result: U, `returnFlag`) =>
+        result
     }
   }
 

--- a/src/test/lisa/lambda-calculus.lisa
+++ b/src/test/lisa/lambda-calculus.lisa
@@ -1,0 +1,79 @@
+(define (bool? true) true)
+(define (bool? false) true)
+(define (bool? _) false)
+
+(define (bind vars vals env)
+    (if (nil? vars) env
+        (bind (cdr vars) (cdr vals) (record-updated env (car vars) (car vals)))))
+(define apply-primitive apply)
+(declare eval apply evlist)
+(define (eval exp env)
+    (cond ((number? exp) exp)
+        ((nil? exp) ())
+        ((string? exp) exp)
+        ((bool? exp) exp)
+        ((symbol? exp) (env exp))
+        ((quoted? exp) (.exp (wrap exp)))
+        ((= (car exp) 'lambda)
+            (list 'closure (cdr exp) env))
+        ((= (car exp) 'if)
+            (if (eval (.[1] exp) env)
+                (eval (.[2] exp) env)
+                (eval (.[3] exp) env)))
+        ((= (car exp) 'closure) exp)
+        (else (apply
+                (eval (car exp) env)
+                (evlist (cdr exp) env)))))
+
+(define (apply proc args)
+    (cond
+        ((procedure? proc) (apply-primitive proc args))
+        ((= (car proc) 'closure)
+            (eval (.[1] (.[1] proc))
+                        (bind (car (.[1] proc))
+                                args
+                                (.[2] proc))))))
+
+(define (evlist exps env)
+    (if (nil? exps)
+        '()
+        (cons (eval (car exps) env) (evlist (cdr exps) env))))
+
+(define Y
+    (eval '(lambda (fn) ((lambda (u) (u u)) (lambda (f) (fn (lambda (s) ((f f) s)))))) (prelude-environment)))
+
+(define primitive
+    (record-updated (prelude-environment) 'Y Y))
+
+(define (make-evaluator)
+    (define-mutable! index)
+    (set! index 0)
+    (define-mutable! inner-env)
+    (set! inner-env primitive)
+    (lambda (exp)
+        (define result (eval exp inner-env))
+        (set! inner-env (record-updated inner-env (string "[" index "]") result))
+        (define return (cons result index))
+        (set! index (+ index 1))
+        return))
+
+(define (eval-lisa exp)
+    (eval exp primitive))
+
+(define (lisa-closure? ('closure (... _))) true)
+(define (lisa-closure? _) false)
+
+(define (display exp)
+    (cond ((lisa-closure? exp) "#<procedure>")
+            (else (string exp))))
+
+(define (interpreter)
+    (define evaluator (make-evaluator))
+    (define (iter)
+        (define raw-input (read "lambda>"))
+        (define result (evaluator raw-input))
+        (println! (string "[" (.[1] result) "]:") (display (car result)))
+        (iter))
+    (iter))
+
+(interpreter)

--- a/src/test/lisa/lambda-calculus.lisa
+++ b/src/test/lisa/lambda-calculus.lisa
@@ -5,6 +5,7 @@
 (define (bind vars vals env)
     (if (nil? vars) env
         (bind (cdr vars) (cdr vals) (record-updated env (car vars) (car vals)))))
+(define builtin-eval eval)
 (define apply-primitive apply)
 (declare eval apply evlist)
 (define (eval exp env)
@@ -67,13 +68,26 @@
     (cond ((lisa-closure? exp) "#<procedure>")
             (else (string exp))))
 
+(define (get-type-of exp)
+    (cond ((lisa-closure? exp) "Closure")
+            (else (typename-of exp))))
+
 (define (interpreter)
     (define evaluator (make-evaluator))
     (define (iter)
         (define raw-input (read "lambda>"))
         (define result (evaluator raw-input))
-        (println! (string "[" (.[1] result) "]:") (display (car result)))
+        (println! (string "[" (.[1] result) "]:") (get-type-of (car result)) "=" (display (car result)))
         (iter))
     (iter))
+
+(define (builtin-interpreter)
+    (define (def-clause? ('define (... _))) true)
+    (define (def-clause? _) false)
+    (while true
+        (group!
+            (define raw-input (read "lisa>"))
+            (if (def-clause? raw-input) (builtin-eval raw-input)
+                (println! (builtin-eval raw-input))))))
 
 (interpreter)

--- a/src/test/lisa/prelude.lisa
+++ b/src/test/lisa/prelude.lisa
@@ -23,20 +23,20 @@
 (define (to-string x)
     (.toString (wrap x)))
 
-(define (cons x y)
-    "Construct a pair, use car to fetch the first and cdr to fetch the second."
-    (define (pair 0) x)
-    (define (pair 1) y)
-    (define (pair 'pair? ) true)
-    (define (pair 'to-string)
-        (+ "[" (to-string x) " " (to-string y) "]"))
-    pair)
-
-(define (pair? pair (when? (pair 'pair? ))) true)
-(define (pair? _) false)
-
-(define (car p (when (pair? p))) (p 0))
-(define (cdr p (when (pair? p))) (p 1))
+# (define (cons x y)
+#     "Construct a pair, use car to fetch the first and cdr to fetch the second."
+#     (define (pair 0) x)
+#     (define (pair 1) y)
+#     (define (pair 'pair? ) true)
+#     (define (pair 'to-string)
+#         (+ "[" (to-string x) " " (to-string y) "]"))
+#     pair)
+#
+# (define (pair? pair (when? (pair 'pair? ))) true)
+# (define (pair? _) false)
+#
+# (define (car p (when (pair? p))) (p 0))
+# (define (cdr p (when (pair? p))) (p 1))
 
 (define-macro (delay e)
     "Construct a lazy value (named promise)."

--- a/src/test/lisa/prelude.lisa
+++ b/src/test/lisa/prelude.lisa
@@ -23,20 +23,20 @@
 (define (to-string x)
     (.toString (wrap x)))
 
-# (define (cons x y)
-#     "Construct a pair, use car to fetch the first and cdr to fetch the second."
-#     (define (pair 0) x)
-#     (define (pair 1) y)
-#     (define (pair 'pair? ) true)
-#     (define (pair 'to-string)
-#         (+ "[" (to-string x) " " (to-string y) "]"))
-#     pair)
-#
-# (define (pair? pair (when? (pair 'pair? ))) true)
-# (define (pair? _) false)
-#
-# (define (car p (when (pair? p))) (p 0))
-# (define (cdr p (when (pair? p))) (p 1))
+; (define (cons x y)
+;     "Construct a pair, use car to fetch the first and cdr to fetch the second."
+;     (define (pair 0) x)
+;     (define (pair 1) y)
+;     (define (pair 'pair? ) true)
+;     (define (pair 'to-string)
+;         (+ "[" (to-string x) " " (to-string y) "]"))
+;     pair)
+;
+; (define (pair? pair (when? (pair 'pair? ))) true)
+; (define (pair? _) false)
+;
+; (define (car p (when (pair? p))) (p 0))
+; (define (cdr p (when (pair? p))) (p 1))
 
 (define-macro (delay e)
     "Construct a lazy value (named promise)."
@@ -97,41 +97,6 @@
 
 (define (bool? f (when? ((constant true) (not f)))) true)
 (define (bool? _) false)
-
-(define (number? n (when? ((constant true) (+ 0 n)))) true)
-(define (number? _) false)
-
-(define (string? n (when? ((constant true) (+ "" n)))) true)
-(define (string? _) false)
-
-(define (closure? c (when? (.startsWith (.toString (wrap c)) "#Closure"))) true)
-(define (closure? c (when? (.startsWith (.toString (wrap c)) "#PolymorphClosure"))) true)
-(define (closure? c (when? (.startsWith (.verboseString (wrap c)) "#PolymorphClosure"))) true)
-(define (closure? _) false)
-
-(define (macro? m (when? (.startsWith (.toString (wrap m)) "#Macro"))) true)
-(define (macro? m (when? (.startsWith (.verboseString (wrap m)) "#PolymorphMacro"))) true)
-(define (macro? _) false)
-
-(define (polymorphic? m (when? (.startsWith (.toString (wrap m)) "#Polymorph"))) true)
-(define (polymorphic? m (when? (.startsWith (.verboseString (wrap m)) "#Polymorph"))) true)
-(define (polymorphic? _) false)
-
-(define (native-function? fn (when? (.startsWith (.toString (wrap fn)) "#[Native Code]"))) true)
-(define (native-function? _) false)
-
-(define (callable? fn)
-    (or
-        (native-function? fn)
-        (or
-            (closure? fn)
-            (macro? fn))))
-
-(define (quoted? x (when? ((constant true) ~x))) true)
-(define (quoted? _) false)
-
-(define (nil? ()) true)
-(define (nil? _) false)
 
 (define (curried-2 fn) ; For procedures with no arity.
     (lambda (x)

--- a/src/test/scala/ExpressionHelper.scala
+++ b/src/test/scala/ExpressionHelper.scala
@@ -31,4 +31,8 @@ trait ExpressionHelper extends Implicits {
     }
   }
 
+  implicit class AnyToLisa[T](value: T)(implicit lift: T => Expression) {
+    def asLisa: Expression = lift(value)
+  }
+
 }

--- a/src/test/scala/MatchArgumentTests.scala
+++ b/src/test/scala/MatchArgumentTests.scala
@@ -23,6 +23,11 @@ class MatchArgumentTests extends AsyncWordSpec with Matchers with ExpressionHelp
       matchArgument(pattern, Nil).value shouldEqual Map("ls" -> LisaList.empty)
       matchArgument(LisaList(pattern) :: Nil, Nil) shouldBe empty
     }
+
+    "match symbols" in {
+      val pattern = List(Quote("a".asSymbol))
+      matchArgument(pattern, "a".asSymbol :: Nil).value shouldBe empty
+    }
   }
 
 }

--- a/src/test/scala/MatchArgumentTests.scala
+++ b/src/test/scala/MatchArgumentTests.scala
@@ -1,0 +1,28 @@
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.OptionValues._
+import org.scalatest.wordspec.AsyncWordSpec
+
+import moe.roselia.lisa
+
+class MatchArgumentTests extends AsyncWordSpec with Matchers with ExpressionHelper {
+  "matchArgument" should {
+    import lisa.Evaluator._
+    import lisa.LispExp._
+
+    "match simple arguments" in {
+      val pattern = "a".asSymbol :: "b".asSymbol :: Nil
+      val arguments: List[Expression] = 1.asLisa :: 2.asLisa :: Nil
+      val matchResult = matchArgument(pattern, arguments).value
+      val expected = pattern.map(_.value).zip(arguments).toMap
+      matchResult should have size 2
+      matchResult shouldEqual expected
+    }
+
+    "handle empty on va-arg" in {
+      val pattern = LisaList("...".asSymbol :: "ls".asSymbol :: Nil) :: Nil
+      matchArgument(pattern, Nil).value shouldEqual Map("ls" -> LisaList.empty)
+      matchArgument(LisaList(pattern) :: Nil, Nil) shouldBe empty
+    }
+  }
+
+}


### PR DESCRIPTION
Some expressions should not be generated ASTs since they should be processed via macros or they are quotations that should not be processed. It has been a design failure for a long time for a Lisp dialect that could not process code structures as data because of strict AST generations.
Introducing `LisaList` for Lisa code data.
`LisaList` is a replacement for `WrappedScalaObject(List[Expression])`. `LisaList` is also a valid Lisa code, which can be processed via `Lisa` code itself.

It is also a design failure that macros are dynamic-scoped. Macros are static-scoped now, referencing values dynamically could be achieved with `dynamic-resolve` macro which only works inside macros.