### PR TITLE
Add functionality to access static members and call constructors.

### DIFF
--- a/README.md
+++ b/README.md
@@ -498,6 +498,29 @@ With pipeline function `|>` with phrase definition in prelude, calling by chain 
     ('elder-than? (Person "Senpai" 24))) ; ==> true
 ```
 
+## Java Inter-Ops
+`Lisa` could deal with `Scala` objects mostly since they are automatically converted to `Lisa`
+objects. To convert Java objects, use pre-defined `from-java` procedure.
+As shown above, variable starts with dot will be treated as method accessors.
+Also, `new` function could be used to call constructor of class like `Clojure`. 
+If you miss `doto` macro, you can just write one as example below.
+```clojure
+(define-macro (doto ex (... ops))
+    (define sym (gen-sym))
+    (define ops-with-obj 
+        (map ops (lambda ((fn (... args))) (cons fn (cons sym args)))))
+    '(let ()
+        (define ~sym ~ex)
+        ~~ops-with-obj
+        ~sym))
+```
+Hence, you can write code like:
+```clojure
+(define array-list (doto (new ArrayList) (.add 1) (.add 2))) ; WrappedScalaObject[ArrayList]
+(define wrapped-list (from-java array-list)) ; WrappedScalaObject[Iterable]
+(define lisa-list (iter wrapped-list)) ; '(1 2)
+```
+
 ## Great! How to use it?
 
 `sbt pack`

--- a/README.md
+++ b/README.md
@@ -521,6 +521,14 @@ Hence, you can write code like:
 (define lisa-list (iter wrapped-list)) ; '(1 2)
 ```
 
+Static members can also be accessed now.
+```clojure
+Math/PI ; = Math.PI
+Integer/MAX_VALUE ; = 2147483647
+(Math/max 1 2) ; = 2
+(String/format "Hello, %s!" "World") ; => "Hello, World!"
+```
+
 ## Great! How to use it?
 
 `sbt pack`

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 name := "lisa"
 
-version := "2.0"
+version := "2.1"
 
 scalaVersion := "2.13.0"
 

--- a/src/main/scala/moe/roselia/lisa/Main.scala
+++ b/src/main/scala/moe/roselia/lisa/Main.scala
@@ -182,6 +182,7 @@ object Main {
         Seq(
           LispExp.LisaRecord.RecordHelperEnv,
           Reflect.DotAccessor.accessEnv,
+          Reflect.StaticFieldAccessor.StaticFieldsAccessorEnvironment,
           Preludes.preludeEnvironment,
           NameSpacedEnv("box", Reflect.ToolboxDotAccessor.accessEnv, "")))
         .withValue("load!", SideEffectFunction {

--- a/src/main/scala/moe/roselia/lisa/Preludes.scala
+++ b/src/main/scala/moe/roselia/lisa/Preludes.scala
@@ -3,8 +3,8 @@ package moe.roselia.lisa
 import moe.roselia.lisa.Environments.{CombineEnv, EmptyEnv, Environment, MutableEnv, NameSpacedEnv, SpecialEnv, TransparentLayer}
 import moe.roselia.lisa.Evaluator.{EvalFailure, EvalFailureMessage, EvalResult, EvalSuccess}
 import moe.roselia.lisa.LispExp._
-import moe.roselia.lisa.Reflect.{PackageAccessor, ToolboxDotAccessor}
-import moe.roselia.lisa.Reflect.ScalaBridge.{fromScalaNative, toScalaNative}
+import moe.roselia.lisa.Reflect.{PackageAccessor, ToolboxDotAccessor, ConstructorCaller}
+import moe.roselia.lisa.Reflect.ScalaBridge.{fromScalaNative, toScalaNative, fromJVMNative}
 
 import scala.util.Try
 
@@ -357,6 +357,10 @@ object Preludes extends LispExp.Implicits {
       require(declares.forall(_.isInstanceOf[Symbol]))
       declares.foreach(sym => mutableEnv.addValue(sym.asInstanceOf[Symbol].value, PlaceHolder))
       NilObj -> mutableEnv
+    },
+    "from-java" -> PrimitiveFunction.withArityChecked(1) {
+      case WrappedScalaObject(x) :: Nil => fromJVMNative(x)
+      case x :: Nil => x
     }
   ))
 
@@ -569,5 +573,9 @@ object Preludes extends LispExp.Implicits {
     }
   ))
 
-  lazy val preludeEnvironment: CombineEnv = CombineEnv(Seq(primitiveEnvironment, collectionEnvironment, testerEnvironment))
+  lazy val preludeEnvironment: CombineEnv = CombineEnv(Seq(
+    primitiveEnvironment,
+    collectionEnvironment,
+    testerEnvironment,
+    ConstructorCaller.ConstructorEnvironment))
 }

--- a/src/main/scala/moe/roselia/lisa/Reflect/ConstructorCaller.scala
+++ b/src/main/scala/moe/roselia/lisa/Reflect/ConstructorCaller.scala
@@ -1,0 +1,90 @@
+package moe.roselia.lisa.Reflect
+
+import moe.roselia.lisa.{Environments, Evaluator, LispExp}
+import moe.roselia.lisa.LispExp.PrimitiveMacro
+import moe.roselia.lisa.Util.Extractors.RichOption
+import moe.roselia.lisa.Reflect.ScalaBridge.{fromScalaNative, toScalaNative}
+
+object ConstructorCaller {
+
+  import reflect.runtime.{universe => ru}
+
+  val searchInPackages = Seq(
+    "scala",
+    "scala.collection",
+    "java.lang",
+    "java.util",
+    "moe.roselia.lisa"
+  )
+
+  def getConstructorSymbol(tpe: ru.ClassSymbol) = {
+    getConstructorOfType(tpe.toType)
+  }
+
+  def resolveClassBySimpleName(name: String): Class[_] = {
+    try {
+      Class.forName(name)
+    } catch {
+      case ex: ClassNotFoundException =>
+        searchInPackages.view
+          .map(pkg => scala.util.Try(Class.forName(s"$pkg.$name")))
+          .collectFirst {
+            case scala.util.Success(clazz) => clazz
+          }.getOrThrow(new ClassNotFoundException(name))
+    }
+  }
+
+  def newInstanceFromClassName(name: String, args: Seq[Any]): Any = {
+    val clazz = resolveClassBySimpleName(name)
+    newInstanceForClass(clazz, args)
+  }
+
+  def newInstanceForClass(clazz: Class[_], args: Seq[Any]): Any = {
+    val classSymbol = getSymbolForClass(clazz)
+    val constructors = getConstructorOfType(classSymbol.toType)
+    val constructorSymbol = findMatchingMethod(constructors, args)
+      .getOrThrow(ScalaReflectionException(s"No matching constructor for ${clazz.getName} with types: ${getTypeNames(args).mkString("(", ", ", ")")}"))
+    val mirror = ru.rootMirror.reflectClass(classSymbol)
+    val method = mirror.reflectConstructor(constructorSymbol)
+    method.apply(args: _*)
+  }
+
+  @`inline` def getTypeNames(xs: Seq[Any]): Seq[String] = xs.map(_.getClass.getName)
+
+  @`inline` def getSymbolForClass(clazz: Class[_]): ru.ClassSymbol = {
+    val runtimeMirror = ru.rootMirror
+    val classSymbol = runtimeMirror.classSymbol(clazz)
+    classSymbol
+  }
+
+  @`inline` def getConstructorOfType(tpe: ru.Type): ru.TermSymbol = tpe.decl(ru.termNames.CONSTRUCTOR).asTerm
+
+  def getMirrorByName(name: String) = {
+    ru.runtimeMirror(Class.forName(name).getClassLoader)
+  }
+
+  def findMatchingMethod(method: ru.TermSymbol, args: Seq[Any]): Option[ru.MethodSymbol] = {
+    val overloads = method.alternatives
+      .filter(_.isMethod)
+      .map(_.asMethod)
+      .filter(_.paramLists.flatten.length == args.length) match {
+      case xs@_ :: Nil => xs
+      case xs => xs.filter(sig => DotAccessor.checkTypeFits(sig.paramLists.flatten)(args))
+    }
+    overloads match {
+      case x :: _ => Some(x)
+      case Nil => None
+    }
+  }
+
+  val ConstructorEnvironment: Environments.Env = Environments.EmptyEnv.withValues(Seq(
+    "new" -> PrimitiveMacro {
+      case (LispExp.Symbol(sym) :: args, env) =>
+        Evaluator.evalList(args, env) match {
+          case Right(exps) =>
+            fromScalaNative(newInstanceFromClassName(sym, exps.map(toScalaNative))) -> env
+          case Left(reason) => throw new RuntimeException(reason)
+        }
+    }.withDocString("General Constructor")
+  ))
+}

--- a/src/main/scala/moe/roselia/lisa/Reflect/PackageAccessor.scala
+++ b/src/main/scala/moe/roselia/lisa/Reflect/PackageAccessor.scala
@@ -37,7 +37,7 @@ object PackageAccessor {
             .map(clsObj.reflectMethod)
           if (nilArityMethod.isDefined) nilArityMethod.map(_.apply()).map(fromScalaNative).get
           else PrimitiveFunction {
-            xs => fromScalaNative(DotAccessor.applyDot(key)(obj)(mapRealArguments(xs): _*))
+            xs => fromScalaNative(DotAccessor.applyDot(key)(obj)(mapRealArguments(xs): _*)(xs: _*))
           }
         }
         else throw ScalaReflectionException(s"$key is not a method")

--- a/src/main/scala/moe/roselia/lisa/Reflect/ScalaBridge.scala
+++ b/src/main/scala/moe/roselia/lisa/Reflect/ScalaBridge.scala
@@ -9,7 +9,7 @@ object ScalaBridge {
 //    println(s"-> ${apply(c, xs.map(fromScalaNative).toList)}")
     val xs = ensureSeq(xOrxs)
     applyToEither(c, xs.map(fromScalaNative).toList)
-      .fold(ex => Failure("Scala Bridge Eval Error", ex), toScalaNative)
+      .fold(ex => throw new RuntimeException(ex), toScalaNative)
   }
 
   private def ensureSeq(xOrxs: Any) = xOrxs match {

--- a/src/main/scala/moe/roselia/lisa/Reflect/ScalaBridge.scala
+++ b/src/main/scala/moe/roselia/lisa/Reflect/ScalaBridge.scala
@@ -38,7 +38,7 @@ object ScalaBridge {
     case ll: LisaListLike[_] => ll
   }
 
-  def fromScalaNative(any: Any): Expression = javaNativeToScala(any) match {
+  def fromScalaNative(any: Any): Expression = any match {
     case list: List[_] =>
       LisaList(list.map(fromScalaNative))
     case ex: Expression => ex
@@ -51,7 +51,7 @@ object ScalaBridge {
     case bi: LisaInteger => SInteger(bi)
     case di: LisaDecimal => SFloat(di)
     case scala.Symbol(sym) => Symbol(sym)
-    case () => NilObj
+    case () | null => NilObj
     // case ls: List[Any] => WrappedScalaObject(ls)
 //    case tuple: Product => LisaList(tuple.productIterator.map(fromScalaNative).toList)
 //    case fn: Function[Any, Any] =>
@@ -59,6 +59,8 @@ object ScalaBridge {
     case Failure(tp, message) => throw new RuntimeException(s"$tp: $message")
     case otherwise => WrappedScalaObject(otherwise)
   }
+
+  def fromJVMNative(any: Any): Expression = fromScalaNative(javaNativeToScala(any))
 
   import scala.jdk.CollectionConverters._
   def javaNativeToScala(original: Any) = original match {

--- a/src/main/scala/moe/roselia/lisa/Reflect/StaticFieldAccessor.scala
+++ b/src/main/scala/moe/roselia/lisa/Reflect/StaticFieldAccessor.scala
@@ -1,0 +1,123 @@
+package moe.roselia.lisa.Reflect
+
+import moe.roselia.lisa.Environments.SpecialEnv
+import moe.roselia.lisa.LispExp
+import moe.roselia.lisa.Util.Extractors.RichOption
+import ScalaBridge.{fromScalaNative, toScalaNative}
+import moe.roselia.lisa.LispExp.PrimitiveFunction
+
+object StaticFieldAccessor {
+  def jvmBoxedClass(clazz: Class[_]): Class[_] = clazz match {
+    case a if a == classOf[Int] => classOf[java.lang.Integer]
+    case a if a == classOf[Boolean] => classOf[java.lang.Boolean]
+    case a if a == classOf[Float] => classOf[java.lang.Float]
+    case a if a == classOf[Double] => classOf[java.lang.Double]
+    case a if a == classOf[Char] => classOf[java.lang.Character]
+    case a if a == classOf[Short] => classOf[java.lang.Short]
+    case a if a == classOf[Byte] => classOf[java.lang.Byte]
+    case a if a == classOf[Long] => classOf[java.lang.Long]
+    case a => a
+  }
+
+  def memberIsStatic(member: java.lang.reflect.Member): Boolean = {
+    (member.getModifiers & java.lang.reflect.Modifier.STATIC) != 0
+  }
+
+  @scala.annotation.tailrec
+  def getStaticMethodOfClassByName(clazz: Class[_], name: String): Seq[java.lang.reflect.Method] = if (clazz eq null) Nil else {
+    clazz.getDeclaredMethods.filter(memberIsStatic).filter(_.getName == name) match {
+      case xs if xs.isEmpty => getStaticMethodOfClassByName(clazz.getSuperclass, name)
+      case xs => xs
+    }
+  }
+
+  @scala.annotation.tailrec
+  def getStaticFiledOfClassByName(clazz: Class[_], name: String): Option[java.lang.reflect.Field] = {
+    if (clazz eq null) None
+    else {
+      clazz.getDeclaredFields.filter(memberIsStatic).find(_.getName == name) match {
+        case None => getStaticFiledOfClassByName(clazz.getSuperclass, name)
+        case x => x
+      }
+    }
+  }
+
+  @`inline` def isTypeFitForJava(params: Seq[Class[_]], arguments: Seq[Any]): Boolean =
+    params.view.map(jvmBoxedClass).zip(arguments).forall(Function.tupled(_ isInstance _))
+
+  def matchRealArguments(params: Seq[Class[_]], arguments: Seq[Any]): Option[Seq[Any]] = {
+    def loop(params: List[Class[_]], arguments: List[Any], buffer: List[Any]): Option[Seq[Any]] = params match {
+      case Nil => if(arguments.isEmpty) Some(buffer.reverse) else None
+      case arrayTpe :: Nil if arrayTpe.isArray =>
+        val underlyingType = jvmBoxedClass(arrayTpe.getComponentType)
+        if (arguments.forall(underlyingType.isInstance))
+          loop(Nil, Nil, arguments.toArray :: buffer)
+        else None
+      case cls :: ps => arguments match {
+        case x :: xs if cls.isInstance(x) => loop(ps, xs, x :: buffer)
+        case _ => None
+      }
+    }
+
+    loop(params.map(jvmBoxedClass).toList, arguments.toList, Nil)
+  }
+
+  def invokeStaticMethodOfClass(clazz: Class[_], name: String)(args: Any*): Option[Any] = {
+    getStaticMethodOfClassByName(clazz, name).find(method => {
+      if(method.isVarArgs) matchRealArguments(method.getParameterTypes, args).isDefined
+      else method.getParameterCount == args.length && isTypeFitForJava(method.getParameterTypes, args)
+    })
+      .map(method => {
+        if (method.isVarArgs) method.invoke(null, matchRealArguments(method.getParameterTypes, args).get: _*)
+        else method.invoke(null, args: _*)
+      })
+  }
+
+  def invokeStaticMethod(clazz: Class[_], name: String)(args: Any*): Any = {
+    invokeStaticMethodOfClass(clazz, name)(args: _*)
+      .getOrThrow(new NoSuchMethodException(s"No matching static method $name for ${clazz.getName} with types: " +
+        s"${ConstructorCaller.getTypeNames(args).mkString("(", ", ", ")")}"))
+  }
+
+  def getStaticFieldValueOfClass(clazz: Class[_], name: String): Option[Any] = {
+    getStaticFiledOfClassByName(clazz, name)
+      .map(_.get(null))
+      // .getOrThrow(new NoSuchFieldException(s"No such filed $name for ${clazz.getName}."))
+  }
+
+  def isFieldOrNilArityMethod(clazz: Class[_], name: String): Boolean = {
+    getStaticFiledOfClassByName(clazz, name).isDefined ||
+      getStaticMethodOfClassByName(clazz, name).exists(_.getParameterCount == 0)
+  }
+
+  def isMethod(clazz: Class[_], name: String): Boolean = {
+    getStaticMethodOfClassByName(clazz, name).nonEmpty
+  }
+
+  def getFieldOrNilArityMethod(clazz: Class[_], name: String): Any = {
+    getStaticFieldValueOfClass(clazz, name)
+      .orElse(invokeStaticMethodOfClass(clazz, name)())
+      .getOrThrow(new NoSuchFieldException(s"No such filed $name for ${clazz.getName}."))
+  }
+
+
+  private object StaticFieldsAccessorImpl extends SpecialEnv {
+    override def getValueOption(key: String): Option[LispExp.Expression] = {
+      key.split('/') match {
+        case Array(className, fieldName) => scala.util.Try {
+          val clazz = ConstructorCaller.resolveClassBySimpleName(className)
+          if (isFieldOrNilArityMethod(clazz, fieldName))
+            fromScalaNative(getFieldOrNilArityMethod(clazz, fieldName))
+          else if(isMethod(clazz, fieldName)) {
+            PrimitiveFunction {
+              xs => fromScalaNative(invokeStaticMethod(clazz, fieldName)(xs.map(toScalaNative): _*))
+            }
+          } else throw new NoSuchMethodException(key)
+        }.toOption
+        case _ => None
+      }
+    }
+  }
+
+  val StaticFieldsAccessorEnvironment: SpecialEnv = SpecialEnv.cached(StaticFieldsAccessorImpl)
+}

--- a/src/main/scala/moe/roselia/lisa/Util/Extractors.scala
+++ b/src/main/scala/moe/roselia/lisa/Util/Extractors.scala
@@ -6,4 +6,10 @@ object Extractors {
 
     def unapply(arg: String): Option[Int] = arg.toIntOption
   }
+
+  implicit class RichOption[T](op: Option[T]) {
+    def getOrThrow[Ex <: Throwable](ex: => Ex): T = {
+      op.getOrElse(throw ex)
+    }
+  }
 }

--- a/src/test/scala/ReflectionTests.scala
+++ b/src/test/scala/ReflectionTests.scala
@@ -123,4 +123,30 @@ class ReflectionTests extends AsyncWordSpec with Matchers {
       newInstanceFromClassName("Some", Seq(1)) shouldEqual Some(1)
     }
   }
+
+  "Static Field Accessor" should {
+    import moe.roselia.lisa.Reflect.StaticFieldAccessor._
+
+    "Access field with names" in {
+      getFieldOrNilArityMethod(classOf[Math], "PI") shouldEqual Math.PI
+      a[NoSuchFieldException] should be thrownBy {
+        getFieldOrNilArityMethod(classOf[Math], "cos")
+      }
+      a [NoSuchFieldException] should be thrownBy {
+        getFieldOrNilArityMethod(classOf[String], "PI")
+      }
+    }
+
+    "Invoke static methods" in {
+      invokeStaticMethod(classOf[String], "valueOf")(114514) shouldEqual "114514"
+      invokeStaticMethod(classOf[Math], "max")(1, 2) shouldEqual 2
+      a[NoSuchMethodException] should be thrownBy invokeStaticMethod(classOf[Math], "max")(2)
+      invokeStaticMethod(classOf[Class[_]], "forName")("java.lang.String") shouldEqual classOf[java.lang.String]
+    }
+
+    "Handle Vararg functions" in {
+      invokeStaticMethod(classOf[String], "format")("%d%s", 2, "33") shouldEqual "233"
+      invokeStaticMethod(classOf[String], "format")("Hello") shouldEqual "Hello"
+    }
+  }
 }

--- a/src/test/scala/ReflectionTests.scala
+++ b/src/test/scala/ReflectionTests.scala
@@ -1,9 +1,18 @@
 import org.scalatest.wordspec.AsyncWordSpec
 import org.scalatest.matchers.should.Matchers
 import moe.roselia.lisa
-import moe.roselia.lisa.LispExp.Expression
+import moe.roselia.lisa.Annotation.RawLisa
+import moe.roselia.lisa.LispExp.{Expression, SInteger, SString}
 
 class ReflectionTests extends AsyncWordSpec with Matchers {
+  class Tester {
+    @RawLisa
+    def lisaString(a: SString): String = a.value
+    @RawLisa
+    def lisaString(i: SInteger): String = i.value.toString
+
+    def lisaString(fn: Double): String = fn.toString
+  }
   "AccessDot" should {
     import lisa.Reflect.DotAccessor.accessDot
     "get nil-arity function" in {
@@ -52,8 +61,8 @@ class ReflectionTests extends AsyncWordSpec with Matchers {
         private def minus(x: Int, y: Int): Int = x - y
       }
 
-      applyDot("addOne")(o)(1) shouldEqual 2
-      applyDot("minus")(o)(2, 3) shouldEqual -1
+      applyDot("addOne")(o)(1)() shouldEqual 2
+      applyDot("minus")(o)(2, 3)() shouldEqual -1
     }
 
     "call parent methods" in {
@@ -61,7 +70,7 @@ class ReflectionTests extends AsyncWordSpec with Matchers {
         def ?+(x: Int, y: Int) = x + y
       }
       class C extends P
-      applyDot("?+")(new C)(2, 3) shouldEqual 5
+      applyDot("?+")(new C)(2, 3)() shouldEqual 5
     }
 
     "should do type check" in {
@@ -70,12 +79,12 @@ class ReflectionTests extends AsyncWordSpec with Matchers {
         def idString(s: lisa.LispExp.SString): String = s.value
       }
 
-      applyDot("idString")(o)("abc") shouldEqual "abc"
+      applyDot("idString")(o)("abc")() shouldEqual "abc"
       a[ScalaReflectionException] should be thrownBy {
-        applyDot("idString")(o)(1)
+        applyDot("idString")(o)(1)()
       }
       a[ScalaReflectionException] should be thrownBy {
-        applyDot("idString")(o)("two", "strings")
+        applyDot("idString")(o)("two", "strings")()
       }
     }
 
@@ -85,11 +94,33 @@ class ReflectionTests extends AsyncWordSpec with Matchers {
         def handleType(i: Int) = "int"
       }
 
-      applyDot("handleType")(o)("s") shouldEqual "string"
-      applyDot("handleType")(o)(233) shouldEqual "int"
+      applyDot("handleType")(o)("s")() shouldEqual "string"
+      applyDot("handleType")(o)(233)() shouldEqual "int"
       a[ScalaReflectionException] should be thrownBy {
-        applyDot("handleType")(o)('a')
+        applyDot("handleType")(o)('a')()
       }
+    }
+
+    "should resolve RawLisa annotation" in {
+      val tester = new Tester
+
+      applyDot("lisaString")(tester)("native")(SString("lisa")) shouldEqual "lisa"
+      applyDot("lisaString")(tester)()(SInteger(233)) shouldEqual "233"
+      applyDot("lisaString")(tester)(114.514)() shouldEqual "114.514"
+      an[Exception] should be thrownBy {
+        applyDot("lisaString")(tester)("no way")()
+      }
+    }
+  }
+
+  "Reflection Constructor" should {
+    import moe.roselia.lisa.Reflect.ConstructorCaller.newInstanceFromClassName
+
+    "construct object from simple names" in {
+      val string = newInstanceFromClassName("String", Seq("string"))
+      string shouldEqual "string"
+
+      newInstanceFromClassName("Some", Seq(1)) shouldEqual Some(1)
     }
   }
 }


### PR DESCRIPTION
Proposed Changes:
* Add `new` macro for calling constructors of classes.
* Add static-members-accessing syntax for slashes like `Clojure`. e.g. Math/PI, String/format

`Lisa` supports get class by `simpleName`, class-lookup will follow procedures below:
1. If the class for this name exists, then the result is this class.
2. Otherwise, search for class in the following packages:
    * scala
    * scala.collection
    * java.lang
    * java.util
    * moe.roselia.lisa