### PR TITLE
Add logical programming module.

### DIFF
--- a/README.md
+++ b/README.md
@@ -597,7 +597,7 @@ Special combinator can help you build powerful queries.
 * `and` Accepts arbitrary queries, the result query will match if all queries match. 
 * `or` Accepts arbitrary queries, the result query will match if one of the queries match. 
 * `but` Accepts a query, the result query will not match if this query matches.
-* `lisa` Accepts an expression evaluated to boolean, the result query will match if the expression is true.
+* `?` Accepts an expression evaluated to boolean, the result query will match if the expression is true.
 * `execute-lisa` Just runs the accepted expression and do nothing to the result.
 * `=` is the unifier that unifies two expressions.
 * `<-` Accepts one symbol and an expression, evaluate the expression and unify the result to that symbol.
@@ -606,7 +606,7 @@ Special combinator can help you build powerful queries.
 (fact (salary a 114))
 (fact (salary b 514))
 
-(query (and (salary x y) (lisa (> y 200)))) ; => ({'x :b 'y 514})
+(query (and (salary x y) (? (> y 200)))) ; => ({'x :b 'y 514})
 (query (and (salary x y) (execute-lisa (println! y)))) ; Prints 114 514 and the result should be ({'x :a 'y 114} {'x :b 'y 514})
 
 (query (= (x x x) ((1 b c) (a 2 c) (a b 3)))); => ({'a 1 'b 2 'c 3 'x (1 2 3)})

--- a/README.md
+++ b/README.md
@@ -553,8 +553,9 @@ Facts can be defined using macro `fact`.
 (fact (path d e))
 (fact (path e f))
 ```
-Notice that you cannot have variables in fact definition. So, symbols in facts are automatically
-transformed to atoms.
+Notice that you usually do not have variables in fact definition. So, symbols in facts are automatically
+transformed to atoms. If you want to use variables, use `'sym`. This **only** works in fact definition.
+`_` matches any case without introducing any new constraints into the environment.
 
 ```clojure
 (fact (path a b)) ; <=> 
@@ -595,6 +596,7 @@ Special combinator can help you build powerful queries.
 * `but` Accepts a query, the result query will not match if this query matches.
 * `lisa` Accepts an expression evaluated to boolean, the result query will match if the expression is true.
 * `execute-lisa` Just runs the accepted expression and do nothing to the result.
+* `=` is the unifier that unifies two expressions.
 
 ```clojure
 (fact (salary a 114))

--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ Note that same variable means same value.
 The last argument in a function definition can be a pattern matching guard.
 It looks like an application of `?`, `when`, or `when?`, like `(? <predicate>)`. 
 
-* `?`, `when` requires that predicate never be failure, if so, matching will result in an evail failure.
+* `?`, `when` requires that predicate never be failure, if so, matching will result in an eval failure.
 * `when?` if predicate returns failure, this branch will be ignored and not match.
 
 The function will match only if the guard predicate indicates true. 
@@ -527,6 +527,81 @@ Math/PI ; = Math.PI
 Integer/MAX_VALUE ; = 2147483647
 (Math/max 1 2) ; = 2
 (String/format "Hello, %s!" "World") ; => "Hello, World!"
+```
+
+## Logical Programming (Experimental)
+Lisa supports logical programming. Lisa has a built-in logical programming system.
+
+### Atoms
+Atom is a special form in Lisa Logical which indicates `atoms`. Atom starts with a `:`
+and follows an identifier or a String. Like `:a`, `:"atom with spaces"`, or `:"b"`.
+`:a` is equal to `:"a"`.
+
+### Logical Module
+To use logical module, you should import that via `(import-env! logical)` first.
+Logical facts and rules are defined in `LogicalContext`s, hence, it is possible to deal with
+multiple logical worlds. To create a context, simply use `(logical/new-context)`.
+
+When a context is created, you can use defined macros like `fact`, `define-rule` and `query`.
+
+### Facts
+Facts are primitives in logical programming.
+Facts can be defined using macro `fact`.
+```clojure
+(fact (path a b))
+(fact (path b c))
+(fact (path d e))
+(fact (path e f))
+```
+Notice that you cannot have variables in fact definition. So, symbols in facts are automatically
+transformed to atoms.
+
+```clojure
+(fact (path a b)) ; <=> 
+(fact (path :a :b))
+```
+
+### Rules
+Rules are means of abstraction in logical programming.
+Rules can be defined via `define-rule`.
+
+```clojure
+(define-rule (link a c)
+    (or (path a c)
+        (and (path a b)
+            (link b c))))
+```
+
+Symbols in rules are treated as variables while atoms are treated as atoms.
+
+### Queries
+Queries are means of combination in logical programming.
+A query can be combines with facts, rules and some special combinator.
+A query can be executed via macro `query`.
+
+```clojure
+(query (link from to)) ; => ({'from :a 'to :b} {'from :b 'to :c} {'from :d 'to :e} {'from :e 'to :f} {'from :a 'to :c} {'from :d 'to :f})
+(query (link :a to)) ; => ({'to :b} {'to :c})
+```
+
+The execution result will be a list of records. An empty list will be emitted if no fact match the query.
+If you only want to test if a fact is true, use `is-true?` macro.
+
+### Combinator
+Special combinator can help you build powerful queries.
+
+* `and` Accepts arbitrary queries, the result query will match if all queries match. 
+* `or` Accepts arbitrary queries, the result query will match if one of the queries match. 
+* `but` Accepts a query, the result query will not match if this query matches.
+* `lisa` Accepts an expression evaluated to boolean, the result query will match if the expression is true.
+* `execute-lisa` Just runs the accepted expression and do nothing to the result.
+
+```clojure
+(fact (salary a 114))
+(fact (salary b 514))
+
+(query (and (salary x y) (lisa (> y 200)))) ; => ({'x :b 'y 514})
+(query (and (salary x y) (execute-lisa (println! y)))) ; Prints 114 514 and the result should be ({'x :a 'y 114} {'x :b 'y 514})
 ```
 
 ## Great! How to use it?

--- a/README.md
+++ b/README.md
@@ -597,6 +597,7 @@ Special combinator can help you build powerful queries.
 * `lisa` Accepts an expression evaluated to boolean, the result query will match if the expression is true.
 * `execute-lisa` Just runs the accepted expression and do nothing to the result.
 * `=` is the unifier that unifies two expressions.
+* `<-` Accepts one symbol and an expression, evaluate the expression and unify the result to that symbol.
 
 ```clojure
 (fact (salary a 114))
@@ -604,6 +605,12 @@ Special combinator can help you build powerful queries.
 
 (query (and (salary x y) (lisa (> y 200)))) ; => ({'x :b 'y 514})
 (query (and (salary x y) (execute-lisa (println! y)))) ; Prints 114 514 and the result should be ({'x :a 'y 114} {'x :b 'y 514})
+
+(query (= (x x x) ((1 b c) (a 2 c) (a b 3)))); => ({'a 1 'b 2 'c 3 'x (1 2 3)})
+
+(define-rule (minus-one x y)
+    (<- y (- x 1)))
+(is-true? (minus-one 3 2)) ; => true
 ```
 
 ## Great! How to use it?

--- a/README.md
+++ b/README.md
@@ -540,7 +540,10 @@ and follows an identifier or a String. Like `:a`, `:"atom with spaces"`, or `:"b
 ### Logical Module
 To use logical module, you should import that via `(import-env! logical)` first.
 Logical facts and rules are defined in `LogicalContext`s, hence, it is possible to deal with
-multiple logical worlds. To create a context, simply use `(logical/new-context)`.
+multiple logical worlds. When a `LogicalContext` is stored in a variable, it is immutable. 
+Use `(current-context)` to get current context, `(pop-context!)` to remove current logical
+context, and `(logical/push-context context)` to set `context` as current context.
+To create a context, simply use `(logical/new-context)`.
 
 When a context is created, you can use defined macros like `fact`, `define-rule` and `query`.
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 name := "lisa"
 
-version := "2.1"
+version := "2.2"
 
 scalaVersion := "2.13.0"
 

--- a/src/main/scala/moe/roselia/lisa/Environments.scala
+++ b/src/main/scala/moe/roselia/lisa/Environments.scala
@@ -23,6 +23,7 @@ object Environments {
   }
   sealed trait Environment extends Identifiable {
     def has(key: String): Boolean = getValueOption(key).isDefined
+    def get(key: String): LispExp.Expression = getValueOption(key).get
     def getValueOption(key: String): Option[LispExp.Expression]
     def newFrame = Env(Map.empty, this)
     def withValue(key: String, value: LispExp.Expression): Env = newFrame withValue (key, value)
@@ -36,6 +37,11 @@ object Environments {
     def collectDefinedValues: Set[String] = Set.empty
     def flatten: Environment = {
       collectValues(collectDefinedValues.toSeq)
+    }
+    def flattenToMap: Map[String, LispExp.Expression] = {
+      collectDefinedValues.map { key =>
+        key -> getValueOption(key).get
+      }.toMap
     }
     def collectValues(values: Seq[String]): Environment = {
       if(values.isEmpty) EmptyEnv

--- a/src/main/scala/moe/roselia/lisa/Environments.scala
+++ b/src/main/scala/moe/roselia/lisa/Environments.scala
@@ -171,10 +171,14 @@ object Environments {
 
     override def collectDefinedValues: Set[String] =
       env.keySet.toSet ++ parent.collectDefinedValues
+
+    def frozen: Env = Env(env.toMap, parent)
   }
 
   object MutableEnv {
-    def createEmpty = MutableEnv(MutableMap.empty, EmptyEnv)
+    def createEmpty: MutableEnv = MutableEnv(MutableMap.empty, EmptyEnv)
+    def fromMap(map: Map[String, LispExp.Expression]): MutableEnv =
+      MutableEnv(MutableMap.from(map), EmptyEnv)
   }
 
   case class NameSpacedEnv(nameSpace: String, env: Environment, separator: String = ".") extends Environment {

--- a/src/main/scala/moe/roselia/lisa/Evaluator.scala
+++ b/src/main/scala/moe/roselia/lisa/Evaluator.scala
@@ -76,11 +76,12 @@ object Evaluator {
     case Value("true") => SBool(true)
     case Value("false") => SBool(false)
     case SUnQuote(q) => UnQuote(compileToList(q))
+    case SAtomLeaf(atom) => LispExp.SAtom(atom)
     case Value(value) => {
       if(value.matches("-?\\d+"))
         SInteger(LisaInteger(value))
       //        value.toIntOption.map(SInteger).getOrElse(SFloat(value.toDouble))
-      else if(value.matches("""([0-9]*\.)?[0-9]+([eE][-+]?[0-9]+)?"""))
+      else if(value.matches("""-?([0-9]*\.)?[0-9]+([eE][-+]?[0-9]+)?"""))
         SFloat(LisaDecimal(value))
       else Symbol(value)
     }
@@ -265,6 +266,7 @@ object Evaluator {
             closure.withDocString(document)
           case _ => closure
         })
+      case id: IdenticalLisaExpression => pureValue(id)
       case c: Closure => pureValue(c)
       case fn: PrimitiveFunction => pureValue(fn)
       case s: SString => pureValue(s)

--- a/src/main/scala/moe/roselia/lisa/Logical/LogicalContext.scala
+++ b/src/main/scala/moe/roselia/lisa/Logical/LogicalContext.scala
@@ -1,0 +1,21 @@
+package moe.roselia.lisa.Logical
+
+import moe.roselia.lisa.LispExp.{Procedure, Expression, LisaList, LisaMapRecord, Closure}
+
+case class LogicalContext(facts: LisaList[Expression], rules: Map[String, LogicalRule]) {
+  def addedRule(name: String, rule: LogicalRule): LogicalContext = {
+    copy(rules = rules.updated(name, rules.getOrElse(name, LogicalRule.empty).mergeVariants(rule)))
+  }
+  def addedFact(fact: Expression): LogicalContext =
+    copy(facts = LisaList(facts.list :+ fact))
+
+  def hasRule(name: String): Boolean = rules contains name
+  def getRule(name: String): Option[LogicalRule] = rules.get(name)
+
+  def findRule(name: String, params: List[Expression]): Option[(Map[String, Expression], Expression)] = {
+    rules.get(name).flatMap(_.findMatch(params))
+  }
+}
+object LogicalContext {
+  def empty: LogicalContext = LogicalContext(LisaList.empty, Map.empty)
+}

--- a/src/main/scala/moe/roselia/lisa/Logical/LogicalContext.scala
+++ b/src/main/scala/moe/roselia/lisa/Logical/LogicalContext.scala
@@ -12,8 +12,8 @@ case class LogicalContext(facts: LisaList[Expression], rules: Map[String, Logica
   def hasRule(name: String): Boolean = rules contains name
   def getRule(name: String): Option[LogicalRule] = rules.get(name)
 
-  def findRule(name: String, params: List[Expression]): Option[(Map[String, Expression], Expression)] = {
-    rules.get(name).flatMap(_.findMatch(params))
+  def findRule(name: String, params: List[Expression]): Seq[((Map[String, Expression], Map[String, Expression]), Expression)] = {
+    rules.get(name).map(_.findMatch(params)).getOrElse(Nil)
   }
 }
 object LogicalContext {

--- a/src/main/scala/moe/roselia/lisa/Logical/LogicalEnvironment.scala
+++ b/src/main/scala/moe/roselia/lisa/Logical/LogicalEnvironment.scala
@@ -64,8 +64,11 @@ case class LogicalEnvironment(var logicalContext: LogicalContext) extends Querie
       case (body :: Nil, e) =>
         factExists(body.toRawList, e) -> e
     },
+    "current-context" -> PrimitiveFunction.withArityChecked(0) { case _ =>
+      WrappedScalaObject(context)
+    },
     "pop-context!" -> SideEffectFunction { case (_, e) =>
-      WrappedScalaObject(context) -> e.collectBy(_ ne implementationsEnvironment)
+      NilObj -> e.collectBy(_ ne implementationsEnvironment)
     }
   ))
 }

--- a/src/main/scala/moe/roselia/lisa/Logical/LogicalEnvironment.scala
+++ b/src/main/scala/moe/roselia/lisa/Logical/LogicalEnvironment.scala
@@ -18,7 +18,7 @@ case class LogicalEnvironment(var logicalContext: LogicalContext) extends Querie
   }
 
   def executeQuery(query: Expression, inEnvironment: Environment): Expression = {
-    matchResultToScalaNative(runMatch(query, inEnvironment))
+    matchResultToLisaNative(runMatch(query, inEnvironment))
   }
 
   def factExists(query: Expression, inEnvironment: Environment): SBool = {

--- a/src/main/scala/moe/roselia/lisa/Logical/LogicalEnvironment.scala
+++ b/src/main/scala/moe/roselia/lisa/Logical/LogicalEnvironment.scala
@@ -1,0 +1,69 @@
+package moe.roselia.lisa.Logical
+
+import moe.roselia.lisa.Environments.{EmptyEnv, Environment}
+import moe.roselia.lisa.LispExp.{Expression, LisaList, NilObj, PrimitiveFunction, PrimitiveMacro, SAtom, SBool, SString, SideEffectFunction, Symbol, WrappedScalaObject}
+
+case class LogicalEnvironment(var logicalContext: LogicalContext) extends Queries {
+  implicit def context: LogicalContext = logicalContext
+
+  def addFact(fact: Expression): Unit = {
+    logicalContext = logicalContext.addedFact(replaceIfPossible(fact, {
+      case Symbol(s) => SAtom(s)
+    }))
+  }
+  def addRule(name: String, rule: LogicalRule): Unit = {
+    logicalContext = logicalContext.addedRule(name, rule)
+  }
+
+  def executeQuery(query: Expression, inEnvironment: Environment): Expression = {
+    matchResultToScalaNative(runMatch(query, inEnvironment))
+  }
+
+  def factExists(query: Expression, inEnvironment: Environment): SBool = {
+    SBool(
+      runMatch(query, inEnvironment).nonEmpty
+    )
+  }
+
+  def runMatch(query: Expression, inEnvironment: Environment): OutputType = {
+    Matcher.runMatcher(
+      compileExpressionToMatcher(query, context, inEnvironment)
+    )
+  }
+
+  lazy val implementationsEnvironment: Environment = EmptyEnv.withValues(Seq(
+    "fact" -> PrimitiveMacro {
+      case (fact :: Nil, e) =>
+        addFact(fact.toRawList)
+        NilObj -> e
+      case (xs, _) => throw new IllegalArgumentException(s"1 argument expected but ${xs.length} found.")
+    },
+    "get-facts" -> PrimitiveFunction.withArityChecked(0) { case _ =>
+      context.facts
+    },
+    "define-rule" -> PrimitiveMacro { case (xs, e) =>
+      xs.map(_.toRawList) match {
+        case LisaList(Symbol(name) :: args) :: body :: Nil =>
+          addRule(name, LogicalRule.createNew(args, body.toRawList))
+          NilObj -> e
+        case LisaList(Symbol(name) :: args) :: Nil => // rule with empty body will always be true.
+          addRule(name, LogicalRule.createNew(args, SBool(true)))
+          NilObj -> e
+      }
+    },
+    "query" -> PrimitiveMacro {
+      case (body :: Nil, e) =>
+        executeQuery(body.toRawList, e) -> e
+    },
+    "execute-query" -> SideEffectFunction { case (body :: Nil, e) =>
+      executeQuery(body, e) -> e
+    },
+    "is-true?" -> PrimitiveMacro {
+      case (body :: Nil, e) =>
+        factExists(body.toRawList, e) -> e
+    },
+    "pop-context!" -> SideEffectFunction { case (_, e) =>
+      WrappedScalaObject(context) -> e.collectBy(_ ne implementationsEnvironment)
+    }
+  ))
+}

--- a/src/main/scala/moe/roselia/lisa/Logical/LogicalEnvironment.scala
+++ b/src/main/scala/moe/roselia/lisa/Logical/LogicalEnvironment.scala
@@ -1,14 +1,16 @@
 package moe.roselia.lisa.Logical
 
 import moe.roselia.lisa.Environments.{EmptyEnv, Environment}
-import moe.roselia.lisa.LispExp.{Expression, LisaList, NilObj, PrimitiveFunction, PrimitiveMacro, SAtom, SBool, SString, SideEffectFunction, Symbol, WrappedScalaObject}
+import moe.roselia.lisa.LispExp.{Expression, LisaList, NilObj, PrimitiveFunction, PrimitiveMacro, Quote, SAtom, SBool, SString, SideEffectFunction, Symbol, WrappedScalaObject}
 
 case class LogicalEnvironment(var logicalContext: LogicalContext) extends Queries {
   implicit def context: LogicalContext = logicalContext
 
   def addFact(fact: Expression): Unit = {
     logicalContext = logicalContext.addedFact(replaceIfPossible(fact, {
+      case s@Symbol("_") => s
       case Symbol(s) => SAtom(s)
+      case Quote(sym@Symbol(_)) => sym
     }))
   }
   def addRule(name: String, rule: LogicalRule): Unit = {

--- a/src/main/scala/moe/roselia/lisa/Logical/LogicalRule.scala
+++ b/src/main/scala/moe/roselia/lisa/Logical/LogicalRule.scala
@@ -8,14 +8,88 @@ case class LogicalRule(variants: List[(List[Expression], Expression)]) {
     copy(variants :+ (params, body))
   def mergeVariants(that: LogicalRule): LogicalRule = copy(variants ::: that.variants)
 
-  def findMatch(params: List[Expression]): Option[(Map[String, Expression], Expression)] = {
+  def findMatch(params: List[Expression]): Seq[((Map[String, Expression], Map[String, Expression]), Expression)] = {
+    /**
+     * Seq[(matchedConstraints, introducedVariables), ruleBody]
+     */
     variants.view.flatMap { case (pattern, body) =>
-      Evaluator.matchArgument(pattern, params).map(_ -> body)
-    }.headOption
+      LogicalRule.matchLogicalRuleArgument(pattern, params).map(_ -> body)
+    }.toSeq
   }
 }
 object LogicalRule {
   def empty: LogicalRule = LogicalRule(Nil)
   def createNew(params: List[Expression], body: Expression): LogicalRule =
     empty.addNewVariant(params, body)
+
+  private type MatchConstraint = collection.mutable.Map[String, Expression]
+  private type FrozenMatchConstraint = Map[String, Expression]
+  def matchLogicalRuleArgument(pattern: List[Expression],
+                               data: List[Expression]): Option[(FrozenMatchConstraint, FrozenMatchConstraint)] = {
+    /** (define-rule (f :a b) ...)
+     *  (query (f x y))
+     *  [[pattern]]: (:a b)
+     *  [[data]]: (x y)
+     *  [[constraints]]: => b -> y
+     *  [[introduced]]: => x -> :a
+     */
+    val introduced: MatchConstraint = collection.mutable.Map.empty
+    val constraints: MatchConstraint = collection.mutable.Map.empty
+    import moe.roselia.lisa.LispExp._
+    def succeed = Some(constraints -> introduced)
+
+    def extend(name: String, exp: Expression, constraint: MatchConstraint): Option[(MatchConstraint, MatchConstraint)] = {
+      if(name == "_") succeed
+      else constraint.get(name) match {
+        case Some(`exp`) => succeed
+        case Some(_) => None
+        case _ =>
+          constraint.update(name, exp)
+          succeed
+      }
+    }
+
+    def matchOne(pattern: Expression, data: Expression): Option[(MatchConstraint, MatchConstraint)] = {
+      if(pattern == data) {
+        pattern match {
+          case Symbol(sym) => constraints.update(sym, data)
+          case _ =>
+        }
+        succeed
+      }
+      else pattern match {
+        case Symbol(name) => extend(name, data, constraints)
+        case _ => data match {
+          case Symbol(name) => extend(name, pattern, introduced)
+          case LisaList(ll2) => data match {
+            case LisaList(ll1) => matchMany(ll1, ll2)
+            case _ => None
+          }
+          case _ => None
+        }
+      }
+    }
+    def matchMany(pattern: List[Expression], data: List[Expression]): Option[(MatchConstraint, MatchConstraint)] = {
+      pattern match {
+        case Nil => if (data.isEmpty) succeed else None
+
+        case LisaList(Symbol("...") :: (sym@Symbol(_)) :: Nil) :: xs =>
+          if (xs.isEmpty) {
+            matchOne(sym, LisaList(data))
+          }
+          else None
+        case otherwise :: xs => data match {
+          case y :: ys => for {
+            _ <- matchOne(otherwise, y)
+            tailMatch <- matchMany(xs, ys)
+          } yield tailMatch
+          case _ => None
+        }
+      }
+    }
+
+    matchMany(pattern, data).map { case (a, b) =>
+      (a.toMap, b.toMap)
+    }
+  }
 }

--- a/src/main/scala/moe/roselia/lisa/Logical/LogicalRule.scala
+++ b/src/main/scala/moe/roselia/lisa/Logical/LogicalRule.scala
@@ -1,0 +1,21 @@
+package moe.roselia.lisa.Logical
+
+import moe.roselia.lisa.Evaluator
+import moe.roselia.lisa.LispExp.Expression
+
+case class LogicalRule(variants: List[(List[Expression], Expression)]) {
+  def addNewVariant(params: List[Expression], body: Expression): LogicalRule =
+    copy(variants :+ (params, body))
+  def mergeVariants(that: LogicalRule): LogicalRule = copy(variants ::: that.variants)
+
+  def findMatch(params: List[Expression]): Option[(Map[String, Expression], Expression)] = {
+    variants.view.flatMap { case (pattern, body) =>
+      Evaluator.matchArgument(pattern, params).map(_ -> body)
+    }.headOption
+  }
+}
+object LogicalRule {
+  def empty: LogicalRule = LogicalRule(Nil)
+  def createNew(params: List[Expression], body: Expression): LogicalRule =
+    empty.addNewVariant(params, body)
+}

--- a/src/main/scala/moe/roselia/lisa/Logical/Queries.scala
+++ b/src/main/scala/moe/roselia/lisa/Logical/Queries.scala
@@ -1,0 +1,238 @@
+package moe.roselia.lisa.Logical
+
+import moe.roselia.lisa.Environments.{CombineEnv, EmptyEnv, Env, Environment, MutableEnv}
+import moe.roselia.lisa.Evaluator
+import moe.roselia.lisa.Evaluator.{EvalFailure, EvalSuccess}
+import moe.roselia.lisa.LispExp.{Expression, LisaList, LisaMapRecord, SAtom, SBool, Symbol}
+
+
+trait Queries {
+  type QuerySeq[T] = LazyList[T]
+  type OutputType = QuerySeq[Environment]
+  type MatcherFunction = (QuerySeq[Environment], LogicalContext) => OutputType
+
+  trait Matcher extends MatcherFunction {
+    def and(that: Matcher): Matcher = (in, lc) => {
+      val thisOut = this(in, lc)
+      that(thisOut, lc)
+    }
+
+    def or(that: Matcher): Matcher = (in, lc) => {
+      val thisOut = this(in, lc)
+      thisOut #::: that(in, lc)
+    }
+
+    def not: Matcher = (in, lc) => {
+      val thisOut = this(in, lc)
+      in.filterNot(m => thisOut.exists(m.eq))
+    }
+  }
+  object Matcher {
+    def success: Matcher = (in, _) => in
+    def fail: Matcher = (_, _) => LazyList.empty
+
+    def and(matchers: Seq[Matcher]): Matcher =
+      matchers.fold(success)(_ and _)
+    def or(matchers: Seq[Matcher]): Matcher =
+      matchers.fold(fail)(_ or _)
+
+    def fromExpression(expression: Expression): Matcher = (in, lc) => {
+      in.flatMap(constraint => {
+        lc.facts.flatMap(unifyMatch(_, expression, constraint.newMutableFrame)).map(_.frozen)
+      })
+    }
+
+    def fromLisa(expression: Expression, capturedEnv: Environment): Matcher = (in, _) => {
+      in.filter { env =>
+        Evaluator.eval(Evaluator.unQuoteList(expression), CombineEnv(env :: capturedEnv :: Nil)) match {
+          case EvalSuccess(SBool(value), _) => value
+          case EvalSuccess(expression, _) =>
+            throw new IllegalStateException(s"Expect a boolean, but $expression: ${expression.tpe.name} found.")
+          case f@EvalFailure(_, _, _) =>
+            throw new RuntimeException(f.toString)
+        }
+      }
+    }
+
+    def lisaExecutor(expression: Expression, capturedEnv: Environment): Matcher = (in, _) => {
+      in.foreach { env =>
+        Evaluator.eval(Evaluator.unQuoteList(expression), CombineEnv(env :: capturedEnv :: Nil))
+      }
+      in
+    }
+
+    def fromRule(rule: LogicalRule, params: List[Expression], capturedEnv: Environment): Matcher = {
+      rule.findMatch(params).map[Matcher] { case (matched, body) =>
+        body match {
+          case SBool(true) =>
+            success
+          case _ => (in, lc) => {
+            val matcher =
+              compileExpressionToMatcher(body, lc, capturedEnv)
+            in.flatMap { previous =>
+              val (undetermined, determined) = matched.partition {
+                case (_, Symbol(s)) => previous.getValueOption(s).forall(_.isInstanceOf[Symbol])
+                case _ => false
+              }
+              val determinedSubstituted = determined.view.mapValues {
+                case Symbol(s) => previous.getValueOption(s).get
+                case x => x
+              }.toMap
+              val inputs = LazyList(MutableEnv.fromMap(determinedSubstituted))
+
+              matcher(inputs, lc).map { m =>
+                undetermined.foldLeft(previous) {
+                  case (e, (from, Symbol(to))) => m.getValueOption(from) match {
+                    case Some(v) => e.withValue(to, v)
+                    case None => e
+                  }
+                  case _ => previous
+                }
+              }
+            }
+          }
+        }
+      }.getOrElse(fail)
+    }
+
+
+    def runMatcher(matcher: Matcher)(implicit context: LogicalContext): OutputType = {
+      matcher(LazyList(MutableEnv.createEmpty), context)
+    }
+  }
+
+  def matchResultToScalaNative(result: OutputType): Expression = LisaList {
+    result.map { e =>
+      LisaMapRecord(e.collectDefinedValues.map(k => k -> e.getValueOption(k).get).toMap)
+    }.toList
+  }
+
+  def hasUndeterminedValue(value: Expression): Boolean = value match {
+    case Symbol(_) => true
+    case LisaList(ll) => ll.exists(hasUndeterminedValue)
+    case _ => false
+  }
+
+  def unwrapOption[T](seq: Seq[Option[T]]): Option[Seq[T]] = {
+    @annotation.tailrec
+    def iter(s: Seq[Option[T]], acc: Seq[T]): Option[Seq[T]] = {
+      if (s.isEmpty) Some(acc)
+      else s.head match {
+        case Some(x) => iter(s.tail, x +: acc)
+        case None => None
+      }
+    }
+    iter(seq, Seq.empty)
+  }
+
+  def trySubstituteValue(expression: Expression, context: Environment): Option[Expression] = expression match {
+    case Symbol(sym) => context.getValueOption(sym).flatMap(trySubstituteValue(_, context))
+    case LisaList(ll) => unwrapOption(ll.map(trySubstituteValue(_, context))).map(_.toList).map(LisaList(_))
+    case x => Some(x)
+  }
+
+  def substituteAllPossibilities(expression: Expression, context: Environment): Expression = expression match {
+    case s @ Symbol(symbol) => context.getValueOption(symbol).getOrElse(s)
+    case LisaList(ll) => LisaList(ll.map(substituteAllPossibilities(_, context)))
+    case x => x
+  }
+
+  def replacePreservingHeads(expression: Expression,
+                             replaceBy: PartialFunction[Expression, Expression]): Expression = expression match {
+    case LisaList(head :: tail) => LisaList(head :: tail.map(replacePreservingHeads(_, replaceBy)))
+    case x => replaceBy.applyOrElse(x, identity[Expression])
+  }
+
+  def replaceIfPossible(expression: Expression,
+                             replaceBy: PartialFunction[Expression, Expression]): Expression = expression match {
+    case LisaList(ll) => LisaList(ll.map(replacePreservingHeads(_, replaceBy)))
+    case x => replaceBy.applyOrElse(x, identity[Expression])
+  }
+
+  def dependsOn(expression: Expression, variable: String, constraint: Environment): Boolean = expression match {
+    case Symbol(`variable`) => true
+    case Symbol(symbol) => constraint.getValueOption(symbol).exists(dependsOn(_, variable, constraint))
+    case LisaList(ll) => ll.exists(dependsOn(_, variable, constraint))
+    case _ => false
+  }
+
+  def extendUndeterminedIfPossible(name: String, exp: Expression, environment: MutableEnv): Option[MutableEnv] = {
+    def extendList(env: Option[MutableEnv]) = {
+      env.foreach { e =>
+        e.addValue(name, substituteAllPossibilities(exp, e))
+      }
+      env
+    }
+    environment.getValueOption(name) match {
+      case Some(x) => extendList(unifyMatch(x, exp, environment))
+      case _ => exp match {
+        case Symbol(sym) => environment.getValueOption(sym) match {
+          case Some(value) => extendList(unifyMatch(Symbol(name), value, environment))
+          case _ =>
+            environment.addValue(name, exp)
+            Some(environment)
+        }
+        case _ =>
+          if (dependsOn(exp, name, environment)) None
+          else Some(environment.addValue(name, exp))
+      }
+    }
+  }
+
+  def matchPatternOfList(pattern: List[Expression],
+                             data: List[Expression],
+                             constraints: MutableEnv = MutableEnv.createEmpty): Option[MutableEnv] = pattern match {
+    case Nil => if (data.isEmpty) Some(constraints) else None
+
+    case LisaList(Symbol("...") :: (sym@Symbol(_)) :: Nil) :: xs =>
+      if (xs.isEmpty) {
+        unifyMatch(sym, LisaList(data), constraints)
+      }
+      else None
+    case otherwise :: xs => data match {
+      case `otherwise` :: ys => matchPatternOfList(xs, ys, constraints)
+      case y :: ys => for {
+        _ <- unifyMatch(otherwise, y, constraints)
+        tailMatch <- matchPatternOfList(xs, ys, constraints)
+      } yield tailMatch
+      case _ => None
+    }
+  }
+
+  def unifyMatch(pattern1: Expression, pattern2: Expression, constraints: MutableEnv): Option[MutableEnv] = {
+    // println(s"Match $pattern1 and $pattern2 with $constraints")
+    if(pattern1 == pattern2) Some(constraints)
+    else pattern1 match {
+      case Symbol(name) => extendUndeterminedIfPossible(name, pattern2, constraints)
+      case _ => pattern2 match {
+        case Symbol(name) => extendUndeterminedIfPossible(name, pattern1, constraints)
+        case LisaList(ll2) => pattern1 match {
+          case LisaList(ll1) => matchPatternOfList(ll1, ll2, constraints)
+          case _ => None
+        }
+        case _ => None
+      }
+    }
+  }
+
+  def compileExpressionToMatcher(expression: Expression,
+                                 context: LogicalContext,
+                                 inEnv: Environment): Matcher = {
+    @`inline` def compile(exp: Expression): Matcher = compileExpressionToMatcher(exp, context, inEnv)
+    expression match {
+      case LisaList(ll) => ll match {
+        case Symbol("and") :: xs => Matcher.and(xs.map(compile))
+        case Symbol("or") :: xs => Matcher.or(xs.map(compile))
+        case Symbol("not") :: x :: Nil => compile(x).not
+        case Symbol("lisa") :: x :: Nil => Matcher.fromLisa(x, inEnv)
+        case Symbol("execute-lisa") :: x :: Nil => Matcher.lisaExecutor(x, inEnv)
+        case Symbol(sym) :: xs if context.hasRule(sym) =>
+          Matcher.fromRule(context.getRule(sym).get, xs, inEnv)
+        case Symbol(sym) :: xs =>
+          Matcher.fromExpression(LisaList(SAtom(sym) :: xs))
+        case xs => Matcher.fromExpression(LisaList(xs))
+      }
+      case x => Matcher.fromExpression(x)
+    }
+  }
+}

--- a/src/main/scala/moe/roselia/lisa/Logical/Queries.scala
+++ b/src/main/scala/moe/roselia/lisa/Logical/Queries.scala
@@ -241,6 +241,9 @@ trait Queries {
       else None
     case otherwise :: xs => data match {
       case `otherwise` :: ys => matchPatternOfList(xs, ys, constraints)
+      case LisaList(Symbol("...") :: (sym@Symbol(_)) :: Nil) :: xs =>
+        if (xs.isEmpty) unifyMatch(LisaList(pattern), sym, constraints)
+        else None
       case y :: ys => for {
         _ <- unifyMatch(otherwise, y, constraints)
         tailMatch <- matchPatternOfList(xs, ys, constraints)

--- a/src/main/scala/moe/roselia/lisa/Logical/Queries.scala
+++ b/src/main/scala/moe/roselia/lisa/Logical/Queries.scala
@@ -3,7 +3,7 @@ package moe.roselia.lisa.Logical
 import moe.roselia.lisa.Environments.{CombineEnv, EmptyEnv, Env, Environment, MutableEnv}
 import moe.roselia.lisa.Evaluator
 import moe.roselia.lisa.Evaluator.{EvalFailure, EvalSuccess}
-import moe.roselia.lisa.LispExp.{Expression, LisaList, LisaMapRecord, SAtom, SBool, Symbol}
+import moe.roselia.lisa.LispExp.{Expression, LisaList, LisaMapRecord, Quote, SAtom, SBool, Symbol}
 
 
 trait Queries {
@@ -277,12 +277,14 @@ trait Queries {
         case Symbol("and") :: xs => Matcher.and(xs.map(compile))
         case Symbol("or") :: xs => Matcher.or(xs.map(compile))
         case Symbol("not") :: x :: Nil => compile(x).not
-        case Symbol("lisa") :: x :: Nil => Matcher.fromLisa(x, inEnv)
+        case Symbol("?") :: x :: Nil => Matcher.fromLisa(x, inEnv)
         case Symbol("execute-lisa") :: x :: Nil => Matcher.lisaExecutor(x, inEnv)
         case Symbol("=") :: lhs :: rhs :: Nil => Matcher.createUnifier(lhs, rhs)
         case Symbol("<-") :: Symbol(name) :: exp :: Nil => Matcher.createAssigner(name, exp, inEnv)
         case Symbol(sym) :: xs if context.hasRule(sym) =>
           Matcher.fromRule(context.getRule(sym).get, xs, inEnv)
+        case Quote(symbol@Symbol(_)) :: xs =>
+          Matcher.fromExpression(LisaList(symbol :: xs))
         case Symbol(sym) :: xs =>
           Matcher.fromExpression(LisaList(SAtom(sym) :: xs))
         case xs => Matcher.fromExpression(LisaList(xs))

--- a/src/main/scala/moe/roselia/lisa/Logical/package.scala
+++ b/src/main/scala/moe/roselia/lisa/Logical/package.scala
@@ -1,0 +1,21 @@
+package moe.roselia.lisa
+
+import moe.roselia.lisa.Environments.{CombineEnv, EmptyEnv, NameSpacedEnv, TransparentLayer}
+import moe.roselia.lisa.LispExp.{NilObj, SideEffectFunction, WrappedScalaObject}
+
+package object Logical {
+  lazy val LogicalModuleEnvironment: NameSpacedEnv = NameSpacedEnv("logical", EmptyEnv.withValues(Seq(
+    "push-context" -> SideEffectFunction {
+      case (WrappedScalaObject(ctx: LogicalContext) :: Nil, e) =>
+        val environment = LogicalEnvironment(ctx)
+        NilObj -> TransparentLayer(environment.implementationsEnvironment, e)
+    },
+    "new-context" -> SideEffectFunction {
+      case (_, e) =>
+        NilObj -> TransparentLayer(
+          LogicalEnvironment(LogicalContext.empty).implementationsEnvironment,
+          e
+        )
+    }
+  )), "/")
+}

--- a/src/main/scala/moe/roselia/lisa/Logical/package.scala
+++ b/src/main/scala/moe/roselia/lisa/Logical/package.scala
@@ -1,7 +1,7 @@
 package moe.roselia.lisa
 
 import moe.roselia.lisa.Environments.{CombineEnv, EmptyEnv, NameSpacedEnv, TransparentLayer}
-import moe.roselia.lisa.LispExp.{NilObj, SideEffectFunction, WrappedScalaObject}
+import moe.roselia.lisa.LispExp.{LisaMapRecord, NilObj, PrimitiveFunction, SideEffectFunction, WrappedScalaObject}
 
 package object Logical {
   lazy val LogicalModuleEnvironment: NameSpacedEnv = NameSpacedEnv("logical", EmptyEnv.withValues(Seq(
@@ -16,6 +16,13 @@ package object Logical {
           LogicalEnvironment(LogicalContext.empty).implementationsEnvironment,
           e
         )
+    },
+    "unify" -> PrimitiveFunction.withArityChecked(2) {
+      case lhs :: rhs :: Nil =>
+        Queries.unifyMatch(lhs, rhs, EmptyEnv.newMutableFrame)
+          .map(_.flattenToMap)
+          .map(LisaMapRecord(_))
+          .getOrElse(NilObj)
     }
   )), "/")
 }

--- a/src/main/scala/moe/roselia/lisa/Preludes.scala
+++ b/src/main/scala/moe/roselia/lisa/Preludes.scala
@@ -251,7 +251,7 @@ object Preludes extends LispExp.Implicits {
       }
       (x, e) match {
         case (Apply(head, tail) :: body, _) =>
-          val toBeDefined = SimpleMacroClosure(head :: tail, body.last, body.init, e)
+          val toBeDefined = SimpleMacroClosure((head :: tail).map(_.toRawList), body.last.toRawList, body.init.map(_.toRawList), e)
           defineHelper(toBeDefined)
         case (Symbol(defined)::Nil, _)
           if e.getValueOption(defined).exists(_.isInstanceOf[SimpleMacroClosure]) =>
@@ -267,8 +267,12 @@ object Preludes extends LispExp.Implicits {
     }.withArity(1),
     "string->symbol" -> PrimitiveFunction {
       case SString(sym)::Nil => Symbol(sym)
-      case _ => Failure("Arity Error", "only accept a string")
+      case _ => Failure("Contract Violation", "only accept a string")
     }.withArity(1),
+    "string->atom" -> PrimitiveFunction.withArityChecked(1) {
+      case SString(sym) :: Nil => SAtom(sym)
+      case _ => Failure("Contract Violation", "only accept a string")
+    },
     "string" -> PrimitiveFunction { xs =>
       xs.mkString
     }.withArity(1),
@@ -539,6 +543,10 @@ object Preludes extends LispExp.Implicits {
     },
     "symbol?" -> PrimitiveFunction.withArityChecked(1) {
       case Symbol(_) :: Nil => true
+      case _ => false
+    },
+    "atom?" -> PrimitiveFunction.withArityChecked(1) {
+      case SAtom(_) :: Nil => true
       case _ => false
     },
     "procedure?" -> PrimitiveFunction.withArityChecked(1) {

--- a/src/main/scala/moe/roselia/lisa/Preludes.scala
+++ b/src/main/scala/moe/roselia/lisa/Preludes.scala
@@ -31,7 +31,8 @@ object Preludes extends LispExp.Implicits {
     "scala-root" -> PackageAccessor.rootScalaEnv,
     "dot-accessor" -> ToolboxDotAccessor.accessEnv,
     "system" -> Library.System.systemEnv,
-    "io-source" -> Library.IOSource.sourceLibrary
+    "io-source" -> Library.IOSource.sourceLibrary,
+    "logical" -> Logical.LogicalModuleEnvironment
   ).view.mapValues(_.withIdentify("prelude"))
 
   private lazy val primitiveEnvironment: Environment = EmptyEnv.withValues(Seq(

--- a/src/main/scala/moe/roselia/lisa/Reflect/DotAccessor.scala
+++ b/src/main/scala/moe/roselia/lisa/Reflect/DotAccessor.scala
@@ -112,6 +112,14 @@ object DotAccessor {
     }].applyDynamic(acc)(args: _*)
   }
 
+  def handleReflectionException[T](block: => T): T = {
+    try block
+    catch {
+      case ex: java.lang.reflect.InvocationTargetException =>
+        throw ex.getTargetException
+    }
+  }
+
   @throws[ScalaReflectionException]("When no underlying method")
   def applyDotOfPlainObject[A : ClassTag](acc: String)(obj: A)(args: Any*)(expressionArgs: Expression*) = {
     val classObj = getClassObject(obj)
@@ -154,7 +162,7 @@ object DotAccessor {
         applyDotDynamic(acc)(dynamic)(args: _*)
       }.getOrElse(applyDotOfPlainObject(acc)(obj)(args: _*)(expressionArgs: _*))
       case _ =>
-        applyDotOfPlainObject(acc)(obj)(args: _*)(expressionArgs: _*)
+        handleReflectionException(applyDotOfPlainObject(acc)(obj)(args: _*)(expressionArgs: _*))
     }
   }
 

--- a/src/main/scala/moe/roselia/lisa/SimpleLispTree.scala
+++ b/src/main/scala/moe/roselia/lisa/SimpleLispTree.scala
@@ -52,4 +52,8 @@ object SimpleLispTree {
   case class PrecompiledSExpression(exp: LispExp.Expression) extends SimpleLispTree {
     override def toString: String = exp.code
   }
+
+  case class SAtomLeaf(value: String) extends SimpleLispTree {
+    override def toString: String = s":$value"
+  }
 }

--- a/src/test/scala/ExpressionHelper.scala
+++ b/src/test/scala/ExpressionHelper.scala
@@ -22,6 +22,7 @@ trait ExpressionHelper extends Implicits {
 
   implicit class StringOps(string: String) {
     def asSymbol = Symbol(string)
+    def asAtom = SAtom(string)
     def toLisa: Expression = {
       val program = string
       import moe.roselia.lisa.SExpressionParser._

--- a/src/test/scala/ExpressionHelper.scala
+++ b/src/test/scala/ExpressionHelper.scala
@@ -1,5 +1,8 @@
 import moe.roselia.lisa
 import lisa.LispExp._
+import moe.roselia.lisa.Environments.{CombineEnv, Environment}
+import moe.roselia.lisa.{Evaluator, Preludes}
+import moe.roselia.lisa.Evaluator.{EvalFailure, EvalSuccess}
 
 trait ExpressionHelper extends Implicits {
   def define(sym: Expression, body: Expression) = Define(sym, body)
@@ -18,6 +21,26 @@ trait ExpressionHelper extends Implicits {
   implicit class ExpressionOps(ex: Expression) {
     def apply(args: Expression*): Expression = Apply(ex, args.toList)
     def quoted = Quote(ex)
+    def evalOn(env: Environment): Expression =
+      Evaluator.eval(ex, env) match {
+        case EvalSuccess(expression, _) => expression
+        case f@EvalFailure(_, _, _) =>
+          org.scalatest.Assertions.fail(f.toString)
+      }
+  }
+
+  implicit class ExpressionListOps(exs: List[Expression]) {
+    def evalOn(env: Environment): List[Expression] = {
+      @scala.annotation.tailrec
+      def traverse(exp: List[Expression], env: Environment, acc: List[Expression] = Nil): List[Expression] = exp match {
+        case Nil => acc.reverse
+        case x :: xs => Evaluator.eval(x, env) match {
+          case EvalSuccess(ee, ev) => traverse(xs, ev, ee :: acc)
+          case f => org.scalatest.Assertions.fail(f.toString)
+        }
+      }
+      traverse(exs, env)
+    }
   }
 
   implicit class StringOps(string: String) {
@@ -30,10 +53,23 @@ trait ExpressionHelper extends Implicits {
       val lisp = parseAll(sExpression, program).get
       moe.roselia.lisa.Evaluator.compile(lisp).ensuring(!_.isInstanceOf[LispExp.Failure])
     }
+    def toListOfLisa: List[Expression] = {
+      val program = string
+      import moe.roselia.lisa.SExpressionParser._
+      import moe.roselia.lisa.LispExp
+      val lisps = parseAll(rep(sExpression), program).get
+      lisps.map(Evaluator.compile).ensuring(_.forall(!_.isInstanceOf[LispExp.Failure]))
+    }
   }
 
   implicit class AnyToLisa[T](value: T)(implicit lift: T => Expression) {
     def asLisa: Expression = lift(value)
+  }
+
+  implicit class EnvHelpers(env: Environment) {
+    def combinedWithPrelude: Environment = CombineEnv(Seq(
+      Preludes.preludeEnvironment, env
+    ))
   }
 
 }

--- a/src/test/scala/LogicalModuleTests.scala
+++ b/src/test/scala/LogicalModuleTests.scala
@@ -1,0 +1,123 @@
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.OptionValues
+import org.scalatest.wordspec.AsyncWordSpec
+import moe.roselia.lisa
+import moe.roselia.lisa.Environments.{EmptyEnv, MutableEnv}
+import moe.roselia.lisa.LispExp.{LisaList, LisaMapRecord}
+import moe.roselia.lisa.Logical.{LogicalContext, LogicalRule}
+
+class LogicalModuleTests extends AsyncWordSpec with Matchers with OptionValues with ExpressionHelper {
+  import lisa.Logical.Queries
+  object Queries extends Queries
+  "unifyMatch" should {
+    "match Lists" in {
+      /**
+       * (x x) match ((1 y 3) (z 2 3))
+       *
+       * x = (1 2 3)
+       * y = 2
+       * z = 1
+      **/
+      val pattern1 = LisaList("x".asSymbol :: "x".asSymbol :: Nil)
+      val pattern2 = LisaList.from(
+        LisaList.fromExpression(1, "y".asSymbol, 3),
+        LisaList.fromExpression("z".asSymbol, 2, 3)
+      )
+
+      val matchResult = Queries.unifyMatch(pattern1, pattern2, EmptyEnv.newMutableFrame).value
+      matchResult.getValueOption("x").value shouldBe LisaList.fromExpression(1, 2, 3)
+      matchResult.getValueOption("y").value shouldBe 2.asLisa
+      matchResult.getValueOption("z").value shouldBe 1.asLisa
+    }
+
+    "match varargs" in {
+      val pattern1 = LisaList.fromExpression(Symbol("x"), LisaList.fromExpression("...".asSymbol, "y".asSymbol))
+      val pattern2 = LisaList.fromExpression(1, 2, 3)
+
+      val matchResult = Queries.unifyMatch(pattern1, pattern2, MutableEnv.createEmpty).value
+
+      matchResult.getValueOption("x").value shouldBe 1.asLisa
+      matchResult.getValueOption("y").value shouldBe LisaList.fromExpression(2, 3)
+    }
+
+    "deal with unknown values" in  {
+      val pattern1 = LisaList("x".asSymbol :: "x".asSymbol :: Nil)
+      val pattern2 = LisaList.from(
+        LisaList.fromExpression("y".asSymbol, 1, "w".asSymbol),
+        LisaList.fromExpression(2, "v".asSymbol, "z".asSymbol)
+      )
+
+      val matchResult = Queries.unifyMatch(pattern1, pattern2, EmptyEnv.newMutableFrame).value
+      matchResult.getValueOption("y").value shouldBe 2.asLisa
+      matchResult.getValueOption("v").value shouldBe 1.asLisa
+      matchResult.getValueOption("w").value shouldBe "z".asSymbol
+      matchResult.getValueOption("x") should contain oneOf(
+          LisaList.fromExpression(2, 1, "w".asSymbol),
+          LisaList.fromExpression(2, 1, "z".asSymbol))
+    }
+
+    "refuse to solve a fix-point equation" in {
+      val pattern1 = LisaList("x".asSymbol :: "x".asSymbol :: Nil)
+      val pattern2 = LisaList.from(
+        "y".asSymbol,
+        LisaList.fromExpression(1, LisaList.fromExpression("...".asSymbol, "y".asSymbol))
+      )
+
+      Queries.unifyMatch(pattern1, pattern2, MutableEnv.createEmpty) shouldBe empty
+    }
+  }
+
+  "expression matcher" should {
+    val context = LogicalContext(LisaList.fromExpression(
+      LisaList.fromExpression("programmer".asSymbol, "linus".asAtom),
+      LisaList.fromExpression("love".asSymbol, "YJSNPI".asAtom, "TON".asAtom),
+      LisaList.fromExpression("love".asSymbol, "MUR".asAtom, "KMR".asAtom)
+    ), Map.empty)
+    "match expressions" in {
+      val matcher = Queries.Matcher.fromExpression(LisaList.fromExpression("programmer".asSymbol, "who".asSymbol))
+      val matchResult = matcher(LazyList(MutableEnv.createEmpty), context)
+      matchResult should have size 1
+      matchResult.head.getValueOption("who").value shouldBe "linus".asAtom
+    }
+    "handle atom case" in {
+      val matcher = Queries.Matcher.fromExpression(LisaList.fromExpression("love".asSymbol, "x".asSymbol, "KMR".asAtom))
+      val matchResult = matcher(LazyList(MutableEnv.createEmpty), context)
+      matchResult should have size 1
+      matchResult.head.getValueOption("x").value shouldBe "MUR".asAtom
+    }
+    "match multiple results if they exist" in {
+      val matcher = Queries.Matcher.fromExpression(LisaList.fromExpression("love".asSymbol, "who".asSymbol, "for".asSymbol))
+      val matchResult = matcher(LazyList(MutableEnv.createEmpty), context)
+      matchResult should have size 2
+    }
+  }
+
+  "rule matcher" should {
+    val context = LogicalContext(LisaList.fromExpression(
+      LisaList.fromExpression("programmer".asSymbol, "linus".asAtom),
+      LisaList.fromExpression("love".asSymbol, "YJSNPI".asAtom, "TON".asAtom),
+      LisaList.fromExpression("love".asSymbol, "TNOK".asAtom, "TNOK".asAtom),
+      LisaList.fromExpression("love".asSymbol, "MUR".asAtom, "KMR".asAtom)
+    ), Map.empty).addedRule("be-loved", LogicalRule(List(
+      List("for", "who").map(_.asSymbol) -> LisaList.fromExpression("love".asSymbol, "who".asSymbol, "for".asSymbol)
+    ))).addedRule("self-loved", LogicalRule(List(
+      List("who".asSymbol) -> LisaList.fromExpression("love".asSymbol, "who".asSymbol, "who".asSymbol)
+    )))
+
+    "apply rules correctly" in {
+      val matcher = Queries.Matcher.fromRule(context.getRule("be-loved").get,
+        List("KMR".asAtom, "who".asSymbol), EmptyEnv)
+      val matchResult = matcher(LazyList(MutableEnv.createEmpty), context)
+      matchResult should have length 1
+      matchResult.head.getValueOption("who").value shouldBe "MUR".asAtom
+    }
+
+    "treat same variables" in {
+      val matcher = Queries.Matcher.fromRule(context.getRule("self-loved").get,
+        List("who".asSymbol), EmptyEnv)
+      val matchResult = matcher(LazyList(MutableEnv.createEmpty), context)
+      matchResult should have length 1
+      matchResult.head.getValueOption("who").value shouldBe "TNOK".asAtom
+    }
+  }
+}

--- a/src/test/scala/LogicalModuleTests.scala
+++ b/src/test/scala/LogicalModuleTests.scala
@@ -38,6 +38,8 @@ class LogicalModuleTests extends AsyncWordSpec with Matchers with OptionValues w
 
       matchResult.getValueOption("x").value shouldBe 1.asLisa
       matchResult.getValueOption("y").value shouldBe LisaList.fromExpression(2, 3)
+
+      Queries.unifyMatch(pattern2, pattern1, MutableEnv.createEmpty).value shouldBe matchResult
     }
 
     "deal with unknown values" in  {

--- a/src/test/scala/MatchArgumentTests.scala
+++ b/src/test/scala/MatchArgumentTests.scala
@@ -1,8 +1,8 @@
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.OptionValues._
 import org.scalatest.wordspec.AsyncWordSpec
-
 import moe.roselia.lisa
+import moe.roselia.lisa.Preludes
 
 class MatchArgumentTests extends AsyncWordSpec with Matchers with ExpressionHelper {
   "matchArgument" should {
@@ -24,9 +24,31 @@ class MatchArgumentTests extends AsyncWordSpec with Matchers with ExpressionHelp
       matchArgument(LisaList(pattern) :: Nil, Nil) shouldBe empty
     }
 
-    "match symbols" in {
+    "match quoted symbols" in {
       val pattern = List(Quote("a".asSymbol))
       matchArgument(pattern, "a".asSymbol :: Nil).value shouldBe empty
+    }
+
+    "match symbols" in {
+      val pattern = List("a".asSymbol, "b".asSymbol)
+      val expected = pattern.map(_.value).zip(pattern).toMap
+      matchArgument(pattern, pattern).value shouldBe expected
+    }
+
+    "handle guard expressions" in {
+      val pattern = List(
+        "a".asSymbol, "b".asSymbol,
+        LisaList.fromExpression("when".asSymbol,
+          LisaList.fromExpression(">".asSymbol, "a".asSymbol, "b".asSymbol))
+      )
+      val data1 = List[Expression](1, 2)
+      val data2 = List[Expression](2, 1)
+      val data2Expected = pattern.collect {
+        case Symbol(s) => s
+      }.zip(data2).toMap
+
+      matchArgument(pattern, data1, inEnv = Preludes.preludeEnvironment) shouldBe empty
+      matchArgument(pattern, data2, inEnv = Preludes.preludeEnvironment).value shouldBe data2Expected
     }
   }
 

--- a/src/test/scala/ReflectionTests.scala
+++ b/src/test/scala/ReflectionTests.scala
@@ -111,6 +111,13 @@ class ReflectionTests extends AsyncWordSpec with Matchers {
         applyDot("lisaString")(tester)("no way")()
       }
     }
+
+    "should not catch control flows" in {
+      val breaks = new util.control.Breaks
+      a[util.control.ControlThrowable] should be thrownBy {
+        applyDot("break")(breaks)()()
+      }
+    }
   }
 
   "Reflection Constructor" should {

--- a/src/test/scala/UtilTests.scala
+++ b/src/test/scala/UtilTests.scala
@@ -1,7 +1,8 @@
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AsyncWordSpec
-
 import moe.roselia.lisa
+import moe.roselia.lisa.Evaluator
+import moe.roselia.lisa.LispExp.{NilObj, PrimitiveFunction}
 
 class UtilTests extends AsyncWordSpec with Matchers {
   "Returnable" should {
@@ -29,6 +30,14 @@ class UtilTests extends AsyncWordSpec with Matchers {
     "produce an exception out of returnable block" in {
       a[lisa.Util.ReturnControlFlow.ReturnException[Int]] should be thrownBy {
         new Returns[Int].returns(1)
+      }
+    }
+
+    "not be caught in applications" in {
+      val ret = new Returns[Any]
+      val retExpr = PrimitiveFunction(_ => ret.returns(NilObj))
+      a[lisa.Util.ReturnControlFlow.ReturnException[_]] should be thrownBy {
+        Evaluator.applyToEither(retExpr, Nil)
       }
     }
   }


### PR DESCRIPTION
Investigating program synthesis for logical problems, we need a bridge language for logic programming, so, we implemented a module for that.

`Logical` Module in Lisa is pluggable, which means we can mix functional programming and logical programming, passing some problems to be solved by the logic module.

Logic Module is implemented via Streams a.k.a LazyList in Scala 2.13. The base of this module is the unify matching, which unifies two expressions and results in the bounding dictionary. Matchers take a stream of dictionaries and unify match them separately. Matchers can be combined via combinators such as `and`, `or` and `not`. 
The logic module is an implementation of SICP Chapter 4.4. 
There is a slight difference that instead of distinguishing variables via question marks, atoms are represented by atoms while variables are represented by symbols.