### PR TITLE
Add String Interpolation

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,8 +101,40 @@ go ; Error: Symbol go not found.
 
 (gen (+ i 1) for i in (list 1 2 3)); <=>
 (map (list 1 2 3) (lambda (i) (+ i 1)))
+```
 
+### String Interpolation
+String Interpolation works in parse time. Such expression will be transformed
+to a procedure application. Such strings are called template strings.
 
+Template strings are literals enclosed by single or triple double quote characters (`"` or `"""`)
+followed an identifier, such as `$"Like $this."`, or`template-name"""string literals"""`.
+Note that there shouldn't be any spaces between identifier and string literal in order to
+distinguish it from an application whose procedure is an identifier and the first argument
+is a string like `(string "string")` is not `(string"string")`.
+
+Template literals can contain placeholders. 
+These are indicated by the dollar sign and curly braces (`${expression}`), 
+Or identifiers with only letters and number after a dollar sign
+(no hyphens, which are legal lisa identifiers) (`$identifier`).
+The expressions in the placeholders and the text between the quotes get passed to a function.
+
+One special template is the dollar sign `$`, this works likes normal string interpolation.
+And such string will compiled to an application of `string` which joins the arguments.
+`$"1 + 1 = ${(+ 1 1)}."` will be transformed to `(string "1 + 1 = " (+ 1 1) ".")`.
+
+Otherwise the templates and placeholders will be transform to the application of that identifier.
+Like `need-lisa"($name $age)"` will be compiled to `(need-lisa '("(" " " ")") (list name age))`.
+So, the return type of template function does not necessarily be a string.
+
+The stand interpolator is `string/interpolate`. Hence, the `need-lisa` procedure can be written as:
+```clojure
+(define (need-lisa parts args)
+    (let ((code (string/interpolate parts args)))
+        (read-string code)))
+(define name "YJSNPI")
+(define age 24)
+need-lisa"($name $age)" ; => (YJSNPI 24)
 ```
 
 ## Start Playing as A Calculator

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 name := "lisa"
 
-version := "2.4"
+version := "2.5"
 
 scalaVersion := "2.13.0"
 

--- a/src/main/scala/moe/roselia/lisa/LispExp.scala
+++ b/src/main/scala/moe/roselia/lisa/LispExp.scala
@@ -245,7 +245,23 @@ object LispExp {
 
   }
 
-  case class SInteger(value: LisaInteger) extends SNumber(value)
+  case class SInteger(value: LisaInteger) extends SNumber(value) {
+    def <<(n: Int): SInteger = SInteger(value << n)
+    def >>(n: Int): SInteger = SInteger(value >> n)
+
+    @RawLisa def % (that: SInteger): SInteger = SInteger(value % that.value)
+    @RawLisa def /% (that: SInteger): LisaList[SInteger] = {
+      val (divider, remainder) = value /% that.value
+      LisaList(List(divider, remainder).map(SInteger(_)))
+    }
+
+    def ~ = SInteger(~value)
+    @RawLisa def &(that: SInteger): SInteger = SInteger(value & that.value)
+    @RawLisa def |(that: SInteger): SInteger = SInteger(value | that.value)
+    @RawLisa def ^(that: SInteger): SInteger = SInteger(value ^ that.value)
+
+    def pow(that: Int): SInteger = SInteger(value pow that)
+  }
 
   object SInteger {
     private val integerCache = (-127 to 128).map(LisaInteger(_)).map(new SInteger(_))

--- a/src/main/scala/moe/roselia/lisa/Logical/Queries.scala
+++ b/src/main/scala/moe/roselia/lisa/Logical/Queries.scala
@@ -7,7 +7,7 @@ import moe.roselia.lisa.LispExp.{Expression, LisaList, LisaMapRecord, Quote, SAt
 
 
 trait Queries {
-  type QuerySeq[T] = LazyList[T]
+  type QuerySeq[+T] = LazyList[T]
   type OutputType = QuerySeq[Environment]
   type MatcherFunction = (QuerySeq[Environment], LogicalContext) => OutputType
 

--- a/src/main/scala/moe/roselia/lisa/Preludes.scala
+++ b/src/main/scala/moe/roselia/lisa/Preludes.scala
@@ -276,6 +276,10 @@ object Preludes extends LispExp.Implicits {
     "string" -> PrimitiveFunction { xs =>
       xs.mkString
     }.withArity(1),
+    "string/interpolate" -> PrimitiveFunction.withArityChecked(2) {
+      case LisaList(part :: parts) :: LisaList(arguments) :: Nil =>
+        (part :: arguments.zip(parts).flatten(x => List(x._1, x._2))).mkString
+    },
     "returnable" -> PrimitiveFunction {
       case fn :: Nil =>
         val returnable = new Util.ReturnControlFlow.Returns
@@ -625,6 +629,21 @@ object Preludes extends LispExp.Implicits {
     },
     "same-reference?" -> PrimitiveFunction.withArityChecked(2) {
       case x :: y :: Nil => x eq y
+    },
+    "not" -> PrimitiveFunction.withArityChecked(1) {
+      case SBool(bool) :: Nil => SBool(!bool)
+    },
+    "and" -> PrimitiveMacro { case (args, env) =>
+      assert(args.length == 2, s"and accepts 2 arguments but got ${args.length}.")
+      val lhs :: rhs :: Nil = args
+      val andSymbol = Symbol("&&the symbol for and&&")
+      Apply(LambdaExpression(SIfElse(andSymbol, rhs, andSymbol), andSymbol :: Nil), lhs :: Nil) -> env
+    },
+    "or" -> PrimitiveMacro { case (args, env) =>
+      assert(args.length == 2, s"or accepts 2 arguments but got ${args.length}.")
+      val lhs :: rhs :: Nil = args
+      val orSymbol = Symbol("&&the symbol for or&&")
+      Apply(LambdaExpression(SIfElse(orSymbol, orSymbol, rhs), orSymbol :: Nil), lhs :: Nil) -> env
     }
   ))
 

--- a/src/main/scala/moe/roselia/lisa/Reflect/ConstructorCaller.scala
+++ b/src/main/scala/moe/roselia/lisa/Reflect/ConstructorCaller.scala
@@ -39,7 +39,7 @@ object ConstructorCaller {
     newInstanceForClass(clazz, args)
   }
 
-  def newInstanceForClass(clazz: Class[_], args: Seq[Any]): Any = {
+  def newInstanceForClass(clazz: Class[_], args: Seq[Any]): Any = DotAccessor.handleReflectionException {
     val classSymbol = getSymbolForClass(clazz)
     val constructors = getConstructorOfType(classSymbol.toType)
     val constructorSymbol = findMatchingMethod(constructors, args)

--- a/src/main/scala/moe/roselia/lisa/Reflect/DotAccessor.scala
+++ b/src/main/scala/moe/roselia/lisa/Reflect/DotAccessor.scala
@@ -48,7 +48,7 @@ object DotAccessor {
         .map(_.asMethod)
         .map(classObj.reflectMethod)
         .map(_.apply())
-        .getOrElse(classObj.reflectField(decl.get.accessed.asTerm).get)
+        .getOrElse(classObj.reflectField(util.Try(decl.get.accessed.asTerm).getOrElse(decl.get)).get)
     } else throw ScalaReflectionException(s"Field or 0-arity method $acc for $obj: ${classObj.symbol.fullName} not found")
   }
 

--- a/src/main/scala/moe/roselia/lisa/Reflect/ScalaBridge.scala
+++ b/src/main/scala/moe/roselia/lisa/Reflect/ScalaBridge.scala
@@ -29,7 +29,9 @@ object ScalaBridge {
     case SRational(rat) =>
       if(rat.isIntegral) {
         val integral = rat.toIntegral
-        if(integral.isValidInt) rat.toIntegral.toInt else integral
+        if(integral.isValidInt) integral.toInt
+        else if (integral.isValidLong) integral.toLong
+        else integral
       } else rat.toDouble
     case sNumber: SNumber[_] => sNumber
     case PrimitiveFunction(fn) => (xs: Any) => fn(ensureSeq(xs).map(fromScalaNative).toList)

--- a/src/main/scala/moe/roselia/lisa/SimpleLispTree.scala
+++ b/src/main/scala/moe/roselia/lisa/SimpleLispTree.scala
@@ -35,6 +35,9 @@ object SimpleLispTree {
   case class StringLiteral(content: String) extends SimpleLispTree {
     override def toString: String = s"${content.replace("\"", "\\\"")}"
   }
+  case class StringTemplate(templateName: String, parts: List[String], arguments: List[SimpleLispTree]) extends SimpleLispTree {
+     override def toString: String = s"$templateName${StringContext(parts: _*).s(arguments: _*)}"
+  }
   case class SList(list: Seq[SimpleLispTree]) extends SimpleLispTree {
     override def toString: String =
       if(list.isEmpty) "( )"

--- a/src/test/scala/EvaluatorTests.scala
+++ b/src/test/scala/EvaluatorTests.scala
@@ -51,4 +51,18 @@ class EvaluatorTests extends AsyncFunSuite with Matchers with ExpressionHelper {
     val factOf10000 = factFunction(10000).pipe(Evaluator.eval(_, EmptyEnv)).asInstanceOf[EvalSuccess].expression
     assert(factOf10000.isInstanceOf[SInteger])
   }
+
+  test("String interpolation should work well") {
+    assert(
+      lisa"""$$"A raw string"""".isInstanceOf[SString], "Empty template should be string only."
+    )
+    assertResult(
+      lisa""" $$"1 + 1 = $${(+ 1 1)}" """
+    )(Apply(symbol"string", "1 + 1 = " :: Apply(symbol"+", 1.asLisa :: 1.asLisa :: Nil) :: "".asLisa :: Nil))
+    assertThrows[Exception](lisa"""s "" """)
+    assertResult(
+      lisa""" s"$$a-b" """
+    )(Apply(symbol"s", LisaList.fromExpression("", "-b") :: Apply(symbol"list", symbol"a" :: Nil) :: Nil))
+    assertResult(lisa""":"atom$$1"""")(SAtom("atom$1"))
+  }
 }


### PR DESCRIPTION
String interpolation is a feature enhancing string formatting functionality. Furthermore, users could define their own procedures to produce different outcomes. Just as JavaScript template string literals, Elixir Sigils, and Scala StringContext, the output could be any type including string.